### PR TITLE
docs: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Go to the `builder` repo in your machine and do this:
 1. Set the `REACT_APP_INSPECTOR_PORT` env var in `.env` to be `8001` (this is the `@dcl/inspector` dev server we started in the previous section).
 2. Set the `REACT_APP_BIN_INDEX_JS_DEV_PORT` to the port where the SDK7 started running (by defualt `8000`).
 3. Set the `REACT_APP_BIN_INDEX_JS_DEV_PATH` env var in `.env` to the path to the `bin/index.js` that you copied in the first section or if you're using docker, set the path to be `/app/bin/index.js`.
-4. Set the `REACT_APP_CATALOG_SERVER_PORT` env var in `.env` to be `8002` (this is the catalog server we started in the first section).
+4. Set the `REACT_APP_CATALOG_URL` env var in `.env` to be `http://localhost:8002` (this is the catalog server we started in the first section).
 5. Run `npm start` to start the builder local server which should start on port `3000`
 
 Now you are all set, you can start developing the SDK7 scene in this repo, use it from the local Builder and test it by previewing the scene, which should use your local Builder Server serving the development javascript files.


### PR DESCRIPTION
This PR updates the README to set the new env var `REACT_APP_CATALOG_URL` in the builder