### PR TITLE
fix: use enum in schema and remove unnecesary check for entity

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -61,7 +61,10 @@ export function createComponents(engine: IEngine) {
           Schemas.Array(
             Schemas.Map({
               entity: Schemas.Optional(Schemas.Entity),
-              type: Schemas.String,
+              type: Schemas.EnumString<TriggerConditionType>(
+                TriggerConditionType,
+                TriggerConditionType.WHEN_STATE_IS,
+              ),
               value: Schemas.String,
             }),
           ),

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -51,32 +51,30 @@ function checkConditions(trigger: Trigger) {
 }
 
 function checkCondition(condition: TriggerCondition) {
-  const entity = Number(condition.entity) as Entity
-  if (isNaN(entity)) {
-    console.error(`Invalid entity in condition`, condition)
-    return
-  }
-  try {
-    switch (condition.type) {
-      case TriggerConditionType.WHEN_STATE_IS: {
-        const states = States.getOrNull(entity)
-        if (states !== null) {
-          const currentValue = getCurrentValue(states)
-          return currentValue === condition.value
+  const entity = condition.entity
+  if (entity) {
+    try {
+      switch (condition.type) {
+        case TriggerConditionType.WHEN_STATE_IS: {
+          const states = States.getOrNull(entity)
+          if (states !== null) {
+            const currentValue = getCurrentValue(states)
+            return currentValue === condition.value
+          }
+          break
         }
-        break
-      }
-      case TriggerConditionType.WHEN_STATE_IS_NOT: {
-        const states = States.getOrNull(entity)
-        if (states !== null) {
-          const currentValue = getCurrentValue(states)
-          return currentValue !== condition.value
+        case TriggerConditionType.WHEN_STATE_IS_NOT: {
+          const states = States.getOrNull(entity)
+          if (states !== null) {
+            const currentValue = getCurrentValue(states)
+            return currentValue !== condition.value
+          }
+          break
         }
-        break
       }
+    } catch (error) {
+      console.error('Error in condition', condition)
     }
-  } catch (error) {
-    console.error('Error in condition', condition)
   }
   return false
 }


### PR DESCRIPTION
- Use enum instead of string in `condition.type`
- Remove unnecesary parsing of `entity` in `checkCondition`