### PR TITLE
feat: use ids for components instead of entity ids

### DIFF
--- a/packs/smart_items/assets/cyberpunk_door/data.json
+++ b/packs/smart_items/assets/cyberpunk_door/data.json
@@ -10,6 +10,7 @@
       "src": "{assetPath}/cyberpunk_door_anim.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -39,14 +40,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -55,14 +56,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -71,14 +72,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -87,14 +88,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -103,7 +104,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -111,6 +112,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/hatch_trapdoor/data.json
+++ b/packs/smart_items/assets/hatch_trapdoor/data.json
@@ -8,6 +8,7 @@
       "src": "{assetPath}/hatch_anim.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -37,14 +38,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -53,14 +54,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -69,14 +70,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -85,14 +86,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -101,7 +102,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -109,6 +110,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/iron_fence_door/data.json
+++ b/packs/smart_items/assets/iron_fence_door/data.json
@@ -10,6 +10,7 @@
       "src": "{assetPath}/door_genesis.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -44,14 +45,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -60,14 +61,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -76,14 +77,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -92,14 +93,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -108,7 +109,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Idle Animation"
             }
           ]
@@ -116,6 +117,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/metal_trapdoor/data.json
+++ b/packs/smart_items/assets/metal_trapdoor/data.json
@@ -12,6 +12,7 @@
       "src": "{assetPath}/grey_trap_door.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -41,14 +42,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -57,14 +58,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -73,14 +74,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -89,14 +90,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -104,6 +105,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/old_wooden_door/data.json
+++ b/packs/smart_items/assets/old_wooden_door/data.json
@@ -10,6 +10,7 @@
       "src": "{assetPath}/door_pirates.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -39,14 +40,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -55,14 +56,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -71,14 +72,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -87,14 +88,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -102,6 +103,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/stone_trapdoor/data.json
+++ b/packs/smart_items/assets/stone_trapdoor/data.json
@@ -12,6 +12,7 @@
       "src": "{assetPath}/stone_trap_door.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -46,14 +47,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -62,14 +63,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -78,14 +79,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -94,14 +95,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -110,7 +111,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Idle Animation"
             }
           ]
@@ -118,6 +119,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/trapdoor/data.json
+++ b/packs/smart_items/assets/trapdoor/data.json
@@ -12,6 +12,7 @@
       "src": "{assetPath}/trap_door.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -46,14 +47,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -62,14 +63,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -78,14 +79,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -94,14 +95,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -110,7 +111,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Idle Animation"
             }
           ]
@@ -118,6 +119,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/vertical_hallway_door/data.json
+++ b/packs/smart_items/assets/vertical_hallway_door/data.json
@@ -13,6 +13,7 @@
       "src": "{assetPath}/vertical_hallway_door.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -47,14 +48,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -63,14 +64,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -79,14 +80,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -95,14 +96,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -111,7 +112,7 @@
           "type": "on_spawn",
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Idle Animation"
             }
           ]
@@ -119,6 +120,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/wooden_door/data.json
+++ b/packs/smart_items/assets/wooden_door/data.json
@@ -8,6 +8,7 @@
       "src": "{assetPath}/door_fantasy.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -37,14 +38,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -53,14 +54,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -69,14 +70,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -85,14 +86,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -100,6 +101,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/packs/smart_items/assets/wooden_trapdoor/data.json
+++ b/packs/smart_items/assets/wooden_trapdoor/data.json
@@ -12,6 +12,7 @@
       "src": "{assetPath}/wooden_trap_door.glb"
     },
     "asset-packs::Actions": {
+      "id": "{self}",
       "value": [
         {
           "name": "Open",
@@ -41,14 +42,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Open"
             }
           ]
@@ -57,14 +58,14 @@
           "type": "on_click",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Close"
             }
           ]
@@ -73,14 +74,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Open"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Open Animation"
             }
           ]
@@ -89,14 +90,14 @@
           "type": "on_state_change",
           "conditions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::States}",
               "type": "when_state_is",
               "value": "Closed"
             }
           ],
           "actions": [
             {
-              "entity": "{selfEntity}",
+              "id": "{self:asset-packs::Actions}",
               "name": "Play Close Animation"
             }
           ]
@@ -104,6 +105,7 @@
       ]
     },
     "asset-packs::States": {
+      "id": "{self}",
       "value": [
         "Open",
         "Closed"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,11 +3,10 @@ import {
   Entity,
   Animator,
   Transform,
-  TransformType,
 } from '@dcl/sdk/ecs'
 import { Quaternion, Vector3 } from '@dcl/sdk/math'
 import * as utils from '@dcl-sdk/utils'
-import { Actions, States } from './components'
+import { Actions, States, Counter } from './components'
 import {
   ActionPayload,
   ActionType,
@@ -61,6 +60,24 @@ export function actionsSystem(_dt: number) {
           }
           case ActionType.START_TWEEN: {
             handleStartTween(entity, getPayload<ActionType.START_TWEEN>(action))
+            break
+          }
+          case ActionType.SET_COUNTER: {
+            handleSetCounter(entity, getPayload<ActionType.SET_COUNTER>(action))
+            break
+          }
+          case ActionType.INCREMENT_COUNTER: {
+            handleIncrementCounter(
+              entity,
+              getPayload<ActionType.INCREMENT_COUNTER>(action),
+            )
+            break
+          }
+          case ActionType.DECREASE_COUNTER: {
+            handleDecreaseCounter(
+              entity,
+              getPayload<ActionType.DECREASE_COUNTER>(action),
+            )
             break
           }
           default:
@@ -215,4 +232,49 @@ function handleScaleItem(
     interpolationType,
     onTweenEnd,
   )
+}
+
+// SET_COUNTER
+function handleSetCounter(
+  entity: Entity,
+  payload: ActionPayload<ActionType.SET_COUNTER>,
+) {
+  const counter = Counter.getMutableOrNull(entity)
+
+  if (counter) {
+    counter.value = payload.counter
+
+    const triggerEvents = getTriggerEvents(entity)
+    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+  }
+}
+
+// INCREMENT_COUNTER
+function handleIncrementCounter(
+  entity: Entity,
+  _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
+) {
+  const counter = Counter.getMutableOrNull(entity)
+
+  if (counter) {
+    counter.value += 1
+
+    const triggerEvents = getTriggerEvents(entity)
+    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+  }
+}
+
+// DECREASE_COUNTER
+function handleDecreaseCounter(
+  entity: Entity,
+  _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
+) {
+  const counter = Counter.getMutableOrNull(entity)
+
+  if (counter) {
+    counter.value -= 1
+
+    const triggerEvents = getTriggerEvents(entity)
+    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+  }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,4 +1,4 @@
 import { engine } from '@dcl/sdk/ecs'
 import { createComponents } from './definitions'
 
-export const { Actions, Triggers, States } = createComponents(engine)
+export const { Actions, Triggers, States, Counter } = createComponents(engine)

--- a/src/id.ts
+++ b/src/id.ts
@@ -1,0 +1,17 @@
+import {
+  IEngine,
+  LastWriteWinElementSetComponentDefinition,
+} from '@dcl/sdk/ecs'
+import { ComponentName, Counter } from './definitions'
+
+export function getCounterComponent(engine: IEngine) {
+  return engine.getComponent(
+    ComponentName.COUNTER,
+  ) as LastWriteWinElementSetComponentDefinition<Counter>
+}
+
+export function getNextId(engine: IEngine) {
+  const Counter = getCounterComponent(engine)
+  const counter = Counter.getOrCreateMutable(engine.RootEntity)
+  return ++counter.value
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import {  engine } from '@dcl/sdk/ecs'
 import { name, version } from '../package.json'
 import { actionsSystem } from './actions'
 import { triggersSystem } from './triggers'
-import { addActionTypes } from './definitions'
+import { initComponents } from './definitions'
 
 export function main() {
   console.log(`Using ${name}@${version}`)
-  addActionTypes(engine)
+  initComponents(engine)
   engine.addSystem(actionsSystem)
   engine.addSystem(triggersSystem)
 }


### PR DESCRIPTION
Use our own ids instead of relying on entity ids which could change between loads of the composite