### PR TITLE
fix: remove import from @dcl-sdk/utils on entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/sdk": "^7.3.12",
         "mitt": "^3.0.1"
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.405.0",
         "@aws-sdk/lib-storage": "^3.405.0",
+        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/hashing": "^3.0.4",
         "@dcl/js-runtime": "7.3.12",
         "@types/mime-types": "^2.1.1",
@@ -857,7 +857,8 @@
     "node_modules/@dcl-sdk/utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
+      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
+      "dev": true
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.1.0",
@@ -7161,7 +7162,8 @@
     "@dcl-sdk/utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
+      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
+      "dev": true
     },
     "@dcl/catalyst-contracts": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.405.0",
     "@aws-sdk/lib-storage": "^3.405.0",
+    "@dcl-sdk/utils": "^1.1.3",
     "@dcl/hashing": "^3.0.4",
     "@dcl/js-runtime": "7.3.12",
     "@types/mime-types": "^2.1.1",
@@ -50,7 +51,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@dcl-sdk/utils": "^1.1.3",
     "@dcl/sdk": "^7.3.12",
     "mitt": "^3.0.1"
   },

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,15 +4,12 @@ import {
   LastWriteWinElementSetComponentDefinition,
   Schemas,
 } from '@dcl/sdk/ecs'
-import { InterpolationType } from '@dcl-sdk/utils'
 import { addActionType } from './action-types'
 
 export * from './action-types'
 export * from './events'
 export * from './id'
 export * from './states'
-
-export { InterpolationType }
 
 export enum ComponentName {
   ACTION_TYPES = 'asset-packs::ActionTypes',
@@ -26,6 +23,25 @@ export enum TweenType {
   MOVE_ITEM = 'move_item',
   ROTATE_ITEM = 'rotate_item',
   SCALE_ITEM = 'scale_item',
+}
+
+export enum InterpolationType {
+  LINEAR = 'linear',
+  EASEINQUAD = 'easeinquad',
+  EASEOUTQUAD = 'easeoutquad',
+  EASEQUAD = 'easequad',
+  EASEINSINE = 'easeinsine',
+  EASEOUTSINE = 'easeoutsine',
+  EASESINE = 'easeinoutsine',
+  EASEINEXPO = 'easeinexpo',
+  EASEOUTEXPO = 'easeoutexpo',
+  EASEEXPO = 'easeinoutexpo',
+  EASEINELASTIC = 'easeinelastic',
+  EASEOUTELASTIC = 'easeoutelastic',
+  EASEELASTIC = 'easeinoutelastic',
+  EASEINBOUNCE = 'easeinbounce',
+  EASEOUTEBOUNCE = 'easeoutbounce',
+  EASEBOUNCE = 'easeinoutbounce',
 }
 
 export enum ActionType {


### PR DESCRIPTION
This seems to be causing issues down the line, because the `@dcl/asset-packs` entrypoint is imported by the `@dcl/inspector` entrypoint which is imported by the `@dcl/sdk` and is causing issues when trying to compile scenes.