### PR TITLE
fix: move to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/sdk": "^7.3.12",
         "mitt": "^3.0.1"
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.405.0",
         "@aws-sdk/lib-storage": "^3.405.0",
-        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/hashing": "^3.0.4",
         "@dcl/js-runtime": "7.3.12",
         "@types/mime-types": "^2.1.1",
@@ -857,8 +857,7 @@
     "node_modules/@dcl-sdk/utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
-      "dev": true
+      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.1.0",
@@ -7162,8 +7161,7 @@
     "@dcl-sdk/utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
-      "dev": true
+      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "@dcl/catalyst-contracts": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.405.0",
     "@aws-sdk/lib-storage": "^3.405.0",
-    "@dcl-sdk/utils": "^1.1.3",
     "@dcl/hashing": "^3.0.4",
     "@dcl/js-runtime": "7.3.12",
     "@types/mime-types": "^2.1.1",
@@ -52,6 +51,7 @@
   },
   "dependencies": {
     "@dcl/sdk": "^7.3.12",
+    "@dcl-sdk/utils": "^1.1.3",
     "mitt": "^3.0.1"
   },
   "prettier": {


### PR DESCRIPTION
This PR moves `@dcl-sdk/utils` back to dependencies, since it will be necessary for the systems to run when imported from VSCode