### PR TITLE
feat: add support for vscode

### DIFF
--- a/src/action-types.ts
+++ b/src/action-types.ts
@@ -1,16 +1,11 @@
-import {
-  IEngine,
-  ISchema,
-  JsonSchemaExtended,
-  LastWriteWinElementSetComponentDefinition,
-  Schemas,
-} from '@dcl/sdk/ecs'
+import { IEngine, ISchema, JsonSchemaExtended, Schemas } from '@dcl/sdk/ecs'
 import {
   Action,
   ActionPayload,
   ActionType,
   ActionTypes,
   ComponentName,
+  getComponent,
 } from './definitions'
 
 export const EMPTY: JsonSchemaExtended = {
@@ -19,18 +14,15 @@ export const EMPTY: JsonSchemaExtended = {
   serializationType: 'map',
 }
 
-export function getActionTypesComponent(engine: IEngine) {
-  return engine.getComponent(
-    ComponentName.ACTION_TYPES,
-  ) as LastWriteWinElementSetComponentDefinition<ActionTypes>
-}
-
 export function addActionType<T extends ISchema>(
   engine: IEngine,
   type: string,
   schema?: T,
 ) {
-  const ActionTypes = getActionTypesComponent(engine)
+  const ActionTypes = getComponent<ActionTypes>(
+    ComponentName.ACTION_TYPES,
+    engine,
+  )
   const actionTypes = ActionTypes.getOrCreateMutable(engine.RootEntity)
   const actionType = {
     type,
@@ -45,7 +37,10 @@ export function addActionType<T extends ISchema>(
 }
 
 export function getActionSchema<T = unknown>(engine: IEngine, type: string) {
-  const ActionTypes = getActionTypesComponent(engine)
+  const ActionTypes = getComponent<ActionTypes>(
+    ComponentName.ACTION_TYPES,
+    engine,
+  )
   const actionTypes = ActionTypes.getOrCreateMutable(engine.RootEntity)
   const actionType = actionTypes.value.find(($) => $.type === type)
   const jsonSchema: JsonSchemaExtended = actionType
@@ -55,7 +50,10 @@ export function getActionSchema<T = unknown>(engine: IEngine, type: string) {
 }
 
 export function getActionTypes(engine: IEngine) {
-  const ActionTypes = getActionTypesComponent(engine)
+  const ActionTypes = getComponent<ActionTypes>(
+    ComponentName.ACTION_TYPES,
+    engine,
+  )
   const actionTypes = ActionTypes.getOrCreateMutable(engine.RootEntity)
   return actionTypes.value.map(($) => $.type)
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,21 +1,22 @@
 import {
-  engine,
+  IEngine,
   Entity,
-  Animator,
-  Transform,
-  AudioSource,
-  VisibilityComponent,
-  AvatarAttach,
-  GltfContainer,
+  AnimatorComponentDefinitionExtended,
+  TransformComponentExtended,
+  LastWriteWinElementSetComponentDefinition,
+  PBAudioSource,
+  PBAvatarAttach,
+  PBVisibilityComponent,
+  PBGltfContainer,
 } from '@dcl/sdk/ecs'
 import { Quaternion, Vector3 } from '@dcl/sdk/math'
 import { tweens } from '@dcl-sdk/utils/dist/tween'
-import { Actions, States, Counter } from './components'
 import {
   ActionPayload,
   ActionType,
   TriggerType,
   TweenType,
+  getComponents,
 } from './definitions'
 import { getDefaultValue, isValidState } from './states'
 import { getActionEvents, getTriggerEvents } from './events'
@@ -23,365 +24,399 @@ import { getPayload } from './action-types'
 
 const initedEntities = new Set<Entity>()
 
-export function actionsSystem(_dt: number) {
-  const entitiesWithActions = engine.getEntitiesWith(Actions)
-  for (const [entity, actions] of entitiesWithActions) {
-    if (initedEntities.has(entity)) {
-      continue
-    }
+export function createActionsSystem(
+  engine: IEngine,
+  components: {
+    Animator: AnimatorComponentDefinitionExtended
+    Transform: TransformComponentExtended
+    AudioSource: LastWriteWinElementSetComponentDefinition<PBAudioSource>
+    AvatarAttach: LastWriteWinElementSetComponentDefinition<PBAvatarAttach>
+    VisibilityComponent: LastWriteWinElementSetComponentDefinition<PBVisibilityComponent>
+    GltfContainer: LastWriteWinElementSetComponentDefinition<PBGltfContainer>
+  },
+) {
+  const {
+    Animator,
+    Transform,
+    AudioSource,
+    AvatarAttach,
+    VisibilityComponent,
+    GltfContainer,
+  } = components
+  const { Actions, States, Counter } = getComponents(engine)
 
-    // initialize actions for given entity
-    const types = actions.value.reduce(
-      (types, action) => types.add(action.type),
-      new Set<String>(),
-    )
-    for (const type of types) {
-      switch (type) {
-        case ActionType.PLAY_ANIMATION: {
-          initPlayAnimation(entity)
-          break
-        }
-        default:
-          break
+  return function actionsSystem(_dt: number) {
+    const entitiesWithActions = engine.getEntitiesWith(Actions)
+
+    for (const [entity, actions] of entitiesWithActions) {
+      if (initedEntities.has(entity)) {
+        continue
       }
-    }
 
-    // bind actions
-    const actionEvents = getActionEvents(entity)
-    for (const action of actions.value) {
-      actionEvents.on(action.name, () => {
-        switch (action.type) {
+      // initialize actions for given entity
+      const types = actions.value.reduce(
+        (types, action) => types.add(action.type),
+        new Set<String>(),
+      )
+
+      for (const type of types) {
+        switch (type) {
           case ActionType.PLAY_ANIMATION: {
-            handlePlayAnimation(
-              entity,
-              getPayload<ActionType.PLAY_ANIMATION>(action),
-            )
-            break
-          }
-          case ActionType.STOP_ANIMATION: {
-            handleStopAnimation(
-              entity,
-              getPayload<ActionType.STOP_ANIMATION>(action),
-            )
-            break
-          }
-          case ActionType.SET_STATE: {
-            handleSetState(entity, getPayload<ActionType.SET_STATE>(action))
-            break
-          }
-          case ActionType.START_TWEEN: {
-            handleStartTween(entity, getPayload<ActionType.START_TWEEN>(action))
-            break
-          }
-          case ActionType.SET_COUNTER: {
-            handleSetCounter(entity, getPayload<ActionType.SET_COUNTER>(action))
-            break
-          }
-          case ActionType.INCREMENT_COUNTER: {
-            handleIncrementCounter(
-              entity,
-              getPayload<ActionType.INCREMENT_COUNTER>(action),
-            )
-            break
-          }
-          case ActionType.DECREASE_COUNTER: {
-            handleDecreaseCounter(
-              entity,
-              getPayload<ActionType.DECREASE_COUNTER>(action),
-            )
-            break
-          }
-          case ActionType.PLAY_SOUND: {
-            handlePlaySound(entity, getPayload<ActionType.PLAY_SOUND>(action))
-            break
-          }
-          case ActionType.STOP_SOUND: {
-            handleStopSound(entity, getPayload<ActionType.STOP_SOUND>(action))
-            break
-          }
-          case ActionType.SET_VISIBILITY: {
-            handleSetVisibility(
-              entity,
-              getPayload<ActionType.SET_VISIBILITY>(action),
-            )
-            break
-          }
-          case ActionType.ATTACH_TO_PLAYER: {
-            handleAttachToPlayer(
-              entity,
-              getPayload<ActionType.ATTACH_TO_PLAYER>(action),
-            )
-            break
-          }
-          case ActionType.DETACH_FROM_PLAYER: {
-            handleDetachFromPlayer(
-              entity,
-              getPayload<ActionType.DETACH_FROM_PLAYER>(action),
-            )
+            initPlayAnimation(entity)
             break
           }
           default:
             break
         }
-      })
+      }
+
+      // bind actions
+      const actionEvents = getActionEvents(entity)
+      for (const action of actions.value) {
+        actionEvents.on(action.name, () => {
+          switch (action.type) {
+            case ActionType.PLAY_ANIMATION: {
+              handlePlayAnimation(
+                entity,
+                getPayload<ActionType.PLAY_ANIMATION>(action),
+              )
+              break
+            }
+            case ActionType.STOP_ANIMATION: {
+              handleStopAnimation(
+                entity,
+                getPayload<ActionType.STOP_ANIMATION>(action),
+              )
+              break
+            }
+            case ActionType.SET_STATE: {
+              handleSetState(entity, getPayload<ActionType.SET_STATE>(action))
+              break
+            }
+            case ActionType.START_TWEEN: {
+              handleStartTween(
+                entity,
+                getPayload<ActionType.START_TWEEN>(action),
+              )
+              break
+            }
+            case ActionType.SET_COUNTER: {
+              handleSetCounter(
+                entity,
+                getPayload<ActionType.SET_COUNTER>(action),
+              )
+              break
+            }
+            case ActionType.INCREMENT_COUNTER: {
+              handleIncrementCounter(
+                entity,
+                getPayload<ActionType.INCREMENT_COUNTER>(action),
+              )
+              break
+            }
+            case ActionType.DECREASE_COUNTER: {
+              handleDecreaseCounter(
+                entity,
+                getPayload<ActionType.DECREASE_COUNTER>(action),
+              )
+              break
+            }
+            case ActionType.PLAY_SOUND: {
+              handlePlaySound(entity, getPayload<ActionType.PLAY_SOUND>(action))
+              break
+            }
+            case ActionType.STOP_SOUND: {
+              handleStopSound(entity, getPayload<ActionType.STOP_SOUND>(action))
+              break
+            }
+            case ActionType.SET_VISIBILITY: {
+              handleSetVisibility(
+                entity,
+                getPayload<ActionType.SET_VISIBILITY>(action),
+              )
+              break
+            }
+            case ActionType.ATTACH_TO_PLAYER: {
+              handleAttachToPlayer(
+                entity,
+                getPayload<ActionType.ATTACH_TO_PLAYER>(action),
+              )
+              break
+            }
+            case ActionType.DETACH_FROM_PLAYER: {
+              handleDetachFromPlayer(
+                entity,
+                getPayload<ActionType.DETACH_FROM_PLAYER>(action),
+              )
+              break
+            }
+            default:
+              break
+          }
+        })
+      }
+
+      initedEntities.add(entity)
     }
-
-    initedEntities.add(entity)
-  }
-}
-
-// PLAY_ANIMATION
-function initPlayAnimation(entity: Entity) {
-  Animator.create(entity, {
-    states: [],
-  })
-  Animator.stopAllAnimations(entity)
-}
-
-function handlePlayAnimation(
-  entity: Entity,
-  payload: ActionPayload<ActionType.PLAY_ANIMATION>,
-) {
-  const { animation, loop } = payload
-
-  const animator = Animator.getMutable(entity)
-  if (!animator.states.some(($) => $.clip === animation)) {
-    animator.states = [
-      ...animator.states,
-      {
-        clip: animation,
-      },
-    ]
   }
 
-  Animator.stopAllAnimations(entity)
-  const clip = Animator.getClip(entity, animation)
-  clip.playing = true
-  clip.loop = loop ?? false
-}
-
-// STOP_ANIMATION
-function handleStopAnimation(
-  entity: Entity,
-  _payload: ActionPayload<ActionType.STOP_ANIMATION>,
-) {
-  if (Animator.has(entity)) {
+  // PLAY_ANIMATION
+  function initPlayAnimation(entity: Entity) {
+    Animator.create(entity, {
+      states: [],
+    })
     Animator.stopAllAnimations(entity)
   }
-}
 
-// SET_STATE
-function handleSetState(
-  entity: Entity,
-  payload: ActionPayload<ActionType.SET_STATE>,
-) {
-  const states = States.getMutableOrNull(entity)
+  function handlePlayAnimation(
+    entity: Entity,
+    payload: ActionPayload<ActionType.PLAY_ANIMATION>,
+  ) {
+    const { animation, loop } = payload
 
-  if (states) {
-    let nextState: string | undefined = payload.state
-    nextState = isValidState(states, nextState)
-      ? nextState
-      : getDefaultValue(states)
-    states.currentValue = nextState
+    const animator = Animator.getMutable(entity)
+    if (!animator.states.some(($) => $.clip === animation)) {
+      animator.states = [
+        ...animator.states,
+        {
+          clip: animation,
+        },
+      ]
+    }
 
-    const triggerEvents = getTriggerEvents(entity)
-    triggerEvents.emit(TriggerType.ON_STATE_CHANGE)
+    Animator.stopAllAnimations(entity)
+    const clip = Animator.getClip(entity, animation)
+    clip.playing = true
+    clip.loop = loop ?? false
   }
-}
 
-// START_TWEEN
-function handleStartTween(
-  entity: Entity,
-  payload: ActionPayload<ActionType.START_TWEEN>,
-) {
-  if (payload) {
-    const triggerEvents = getTriggerEvents(entity)
-    const onTweenEnd = () => triggerEvents.emit(TriggerType.ON_TWEEN_END)
+  // STOP_ANIMATION
+  function handleStopAnimation(
+    entity: Entity,
+    _payload: ActionPayload<ActionType.STOP_ANIMATION>,
+  ) {
+    if (Animator.has(entity)) {
+      Animator.stopAllAnimations(entity)
+    }
+  }
 
-    switch (payload.type) {
-      case TweenType.MOVE_ITEM: {
-        handleMoveItem(entity, payload, onTweenEnd)
-        break
-      }
-      case TweenType.ROTATE_ITEM: {
-        handleRotateItem(entity, payload, onTweenEnd)
-        break
-      }
-      case TweenType.SCALE_ITEM: {
-        handleScaleItem(entity, payload, onTweenEnd)
-        break
-      }
-      default: {
-        throw new Error(`Unknown tween type: ${payload.type}`)
+  // SET_STATE
+  function handleSetState(
+    entity: Entity,
+    payload: ActionPayload<ActionType.SET_STATE>,
+  ) {
+    const states = States.getMutableOrNull(entity)
+
+    if (states) {
+      let nextState: string | undefined = payload.state
+      nextState = isValidState(states, nextState)
+        ? nextState
+        : getDefaultValue(states)
+      states.currentValue = nextState
+
+      const triggerEvents = getTriggerEvents(entity)
+      triggerEvents.emit(TriggerType.ON_STATE_CHANGE)
+    }
+  }
+
+  // START_TWEEN
+  function handleStartTween(
+    entity: Entity,
+    payload: ActionPayload<ActionType.START_TWEEN>,
+  ) {
+    if (payload) {
+      const triggerEvents = getTriggerEvents(entity)
+      const onTweenEnd = () => triggerEvents.emit(TriggerType.ON_TWEEN_END)
+
+      switch (payload.type) {
+        case TweenType.MOVE_ITEM: {
+          handleMoveItem(entity, payload, onTweenEnd)
+          break
+        }
+        case TweenType.ROTATE_ITEM: {
+          handleRotateItem(entity, payload, onTweenEnd)
+          break
+        }
+        case TweenType.SCALE_ITEM: {
+          handleScaleItem(entity, payload, onTweenEnd)
+          break
+        }
+        default: {
+          throw new Error(`Unknown tween type: ${payload.type}`)
+        }
       }
     }
   }
-}
 
-// MOVE_ITEM
-function handleMoveItem(
-  entity: Entity,
-  tween: ActionPayload<ActionType.START_TWEEN>,
-  onTweenEnd: () => void,
-) {
-  const transform = Transform.get(entity)
-  const { duration, interpolationType, relative } = tween
-  const end = Vector3.create(tween.end.x, tween.end.y, tween.end.z)
-  const endPosition = relative ? Vector3.add(transform.position, end) : end
+  // MOVE_ITEM
+  function handleMoveItem(
+    entity: Entity,
+    tween: ActionPayload<ActionType.START_TWEEN>,
+    onTweenEnd: () => void,
+  ) {
+    const transform = Transform.get(entity)
+    const { duration, interpolationType, relative } = tween
+    const end = Vector3.create(tween.end.x, tween.end.y, tween.end.z)
+    const endPosition = relative ? Vector3.add(transform.position, end) : end
 
-  tweens.startTranslation(
-    entity,
-    transform.position,
-    endPosition,
-    duration,
-    interpolationType,
-    onTweenEnd,
-  )
-}
-
-// ROTATE_ITEM
-function handleRotateItem(
-  entity: Entity,
-  tween: ActionPayload<ActionType.START_TWEEN>,
-  onTweenEnd: () => void,
-) {
-  const transform = Transform.get(entity)
-  const { duration, interpolationType, relative } = tween
-  const end = Quaternion.fromEulerDegrees(tween.end.x, tween.end.y, tween.end.z)
-  const endRotation = relative
-    ? Quaternion.multiply(transform.rotation, end)
-    : end
-
-  tweens.startRotation(
-    entity,
-    transform.rotation,
-    endRotation,
-    duration,
-    interpolationType,
-    onTweenEnd,
-  )
-}
-
-// SCALE_ITEM
-function handleScaleItem(
-  entity: Entity,
-  tween: ActionPayload<ActionType.START_TWEEN>,
-  onTweenEnd: () => void,
-) {
-  const transform = Transform.get(entity)
-  const { duration, interpolationType, relative } = tween
-  const end = Vector3.create(tween.end.x, tween.end.y, tween.end.z)
-  const endScale = relative ? Vector3.add(transform.scale, end) : end
-
-  tweens.startScaling(
-    entity,
-    transform.scale,
-    endScale,
-    duration,
-    interpolationType,
-    onTweenEnd,
-  )
-}
-
-// SET_COUNTER
-function handleSetCounter(
-  entity: Entity,
-  payload: ActionPayload<ActionType.SET_COUNTER>,
-) {
-  const counter = Counter.getMutableOrNull(entity)
-
-  if (counter) {
-    counter.value = payload.counter
-
-    const triggerEvents = getTriggerEvents(entity)
-    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    tweens.startTranslation(
+      entity,
+      transform.position,
+      endPosition,
+      duration,
+      interpolationType,
+      onTweenEnd,
+    )
   }
-}
 
-// INCREMENT_COUNTER
-function handleIncrementCounter(
-  entity: Entity,
-  _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
-) {
-  const counter = Counter.getMutableOrNull(entity)
+  // ROTATE_ITEM
+  function handleRotateItem(
+    entity: Entity,
+    tween: ActionPayload<ActionType.START_TWEEN>,
+    onTweenEnd: () => void,
+  ) {
+    const transform = Transform.get(entity)
+    const { duration, interpolationType, relative } = tween
+    const end = Quaternion.fromEulerDegrees(
+      tween.end.x,
+      tween.end.y,
+      tween.end.z,
+    )
+    const endRotation = relative
+      ? Quaternion.multiply(transform.rotation, end)
+      : end
 
-  if (counter) {
-    counter.value += 1
-
-    const triggerEvents = getTriggerEvents(entity)
-    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    tweens.startRotation(
+      entity,
+      transform.rotation,
+      endRotation,
+      duration,
+      interpolationType,
+      onTweenEnd,
+    )
   }
-}
 
-// DECREASE_COUNTER
-function handleDecreaseCounter(
-  entity: Entity,
-  _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
-) {
-  const counter = Counter.getMutableOrNull(entity)
+  // SCALE_ITEM
+  function handleScaleItem(
+    entity: Entity,
+    tween: ActionPayload<ActionType.START_TWEEN>,
+    onTweenEnd: () => void,
+  ) {
+    const transform = Transform.get(entity)
+    const { duration, interpolationType, relative } = tween
+    const end = Vector3.create(tween.end.x, tween.end.y, tween.end.z)
+    const endScale = relative ? Vector3.add(transform.scale, end) : end
 
-  if (counter) {
-    counter.value -= 1
-
-    const triggerEvents = getTriggerEvents(entity)
-    triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    tweens.startScaling(
+      entity,
+      transform.scale,
+      endScale,
+      duration,
+      interpolationType,
+      onTweenEnd,
+    )
   }
-}
 
-// PLAY_SOUND
-function handlePlaySound(
-  entity: Entity,
-  payload: ActionPayload<ActionType.PLAY_SOUND>,
-) {
-  const { src, loop, volume } = payload
-  AudioSource.createOrReplace(entity, {
-    audioClipUrl: src,
-    loop,
-    playing: true,
-    volume: volume ?? 1,
-  })
-}
+  // SET_COUNTER
+  function handleSetCounter(
+    entity: Entity,
+    payload: ActionPayload<ActionType.SET_COUNTER>,
+  ) {
+    const counter = Counter.getMutableOrNull(entity)
 
-// STOP_SOUND
-function handleStopSound(
-  entity: Entity,
-  _payload: ActionPayload<ActionType.STOP_SOUND>,
-) {
-  const audioSource = AudioSource.getMutableOrNull(entity)
-  if (audioSource) {
-    audioSource.playing = false
+    if (counter) {
+      counter.value = payload.counter
+
+      const triggerEvents = getTriggerEvents(entity)
+      triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    }
   }
-}
 
-// SET_VISIBILITY
-function handleSetVisibility(
-  entity: Entity,
-  payload: ActionPayload<ActionType.SET_VISIBILITY>,
-) {
-  const { visible, physicsCollider } = payload
-  VisibilityComponent.createOrReplace(entity, { visible })
-  const gltf = GltfContainer.getMutableOrNull(entity)
+  // INCREMENT_COUNTER
+  function handleIncrementCounter(
+    entity: Entity,
+    _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
+  ) {
+    const counter = Counter.getMutableOrNull(entity)
 
-  if (gltf && physicsCollider !== undefined) {
-    gltf.invisibleMeshesCollisionMask = physicsCollider ? 2 : 0
+    if (counter) {
+      counter.value += 1
+
+      const triggerEvents = getTriggerEvents(entity)
+      triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    }
   }
-}
 
-// ATTACH_TO_PLAYER
-function handleAttachToPlayer(
-  entity: Entity,
-  payload: ActionPayload<ActionType.ATTACH_TO_PLAYER>,
-) {
-  const { anchorPointId } = payload
-  AvatarAttach.createOrReplace(entity, { anchorPointId })
-}
+  // DECREASE_COUNTER
+  function handleDecreaseCounter(
+    entity: Entity,
+    _payload: ActionPayload<ActionType.INCREMENT_COUNTER>,
+  ) {
+    const counter = Counter.getMutableOrNull(entity)
 
-// DETACH_FROM_PLAYER
-function handleDetachFromPlayer(
-  entity: Entity,
-  _payload: ActionPayload<ActionType.DETACH_FROM_PLAYER>,
-) {
-  if (AvatarAttach.has(entity)) {
-    AvatarAttach.deleteFrom(entity)
+    if (counter) {
+      counter.value -= 1
+
+      const triggerEvents = getTriggerEvents(entity)
+      triggerEvents.emit(TriggerType.ON_COUNTER_CHANGE)
+    }
+  }
+
+  // PLAY_SOUND
+  function handlePlaySound(
+    entity: Entity,
+    payload: ActionPayload<ActionType.PLAY_SOUND>,
+  ) {
+    const { src, loop, volume } = payload
+    AudioSource.createOrReplace(entity, {
+      audioClipUrl: src,
+      loop,
+      playing: true,
+      volume: volume ?? 1,
+    })
+  }
+
+  // STOP_SOUND
+  function handleStopSound(
+    entity: Entity,
+    _payload: ActionPayload<ActionType.STOP_SOUND>,
+  ) {
+    const audioSource = AudioSource.getMutableOrNull(entity)
+    if (audioSource) {
+      audioSource.playing = false
+    }
+  }
+
+  // SET_VISIBILITY
+  function handleSetVisibility(
+    entity: Entity,
+    payload: ActionPayload<ActionType.SET_VISIBILITY>,
+  ) {
+    const { visible, physicsCollider } = payload
+    VisibilityComponent.createOrReplace(entity, { visible })
+    const gltf = GltfContainer.getMutableOrNull(entity)
+
+    if (gltf && physicsCollider !== undefined) {
+      gltf.invisibleMeshesCollisionMask = physicsCollider ? 2 : 0
+    }
+  }
+
+  // ATTACH_TO_PLAYER
+  function handleAttachToPlayer(
+    entity: Entity,
+    payload: ActionPayload<ActionType.ATTACH_TO_PLAYER>,
+  ) {
+    const { anchorPointId } = payload
+    AvatarAttach.createOrReplace(entity, { anchorPointId })
+  }
+
+  // DETACH_FROM_PLAYER
+  function handleDetachFromPlayer(
+    entity: Entity,
+    _payload: ActionPayload<ActionType.DETACH_FROM_PLAYER>,
+  ) {
+    if (AvatarAttach.has(entity)) {
+      AvatarAttach.deleteFrom(entity)
+    }
   }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,4 +1,0 @@
-import { engine } from '@dcl/sdk/ecs'
-import { createComponents } from './definitions'
-
-export const { Actions, Triggers, States, Counter } = createComponents(engine)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -125,6 +125,28 @@ export enum TriggerConditionOperation {
   OR = 'or',
 }
 
+export function getComponent<T>(componentName: string, engine: IEngine) {
+  try {
+    return engine.getComponent(
+      componentName,
+    ) as LastWriteWinElementSetComponentDefinition<T>
+  } catch (error) {
+    console.error(
+      `Error using getComponent with componentName="${componentName}"`,
+    )
+    throw error
+  }
+}
+
+export function getComponents(engine: IEngine) {
+  return {
+    Actions: getComponent<Actions>(ComponentName.ACTIONS, engine),
+    States: getComponent<States>(ComponentName.STATES, engine),
+    Counter: getComponent<Counter>(ComponentName.COUNTER, engine),
+    Triggers: getComponent<Triggers>(ComponentName.TRIGGERS, engine),
+  }
+}
+
 export function createComponents(engine: IEngine) {
   const ActionTypes = engine.defineComponent(ComponentName.ACTION_TYPES, {
     value: Schemas.Array(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,24 @@
-import {  engine } from '@dcl/sdk/ecs'
-import { name, version } from '../package.json'
-import { actionsSystem } from './actions'
-import { triggersSystem } from './triggers'
-import { initComponents } from './definitions'
+import {
+  engine,
+  pointerEventsSystem,
+  Animator,
+  Transform,
+  AudioSource,
+  AvatarAttach,
+  VisibilityComponent,
+  GltfContainer,
+} from '@dcl/sdk/ecs'
+import { initAssetPacks } from './scene-entrypoint'
+
+initAssetPacks(engine, pointerEventsSystem, {
+  Animator,
+  Transform,
+  AudioSource,
+  AvatarAttach,
+  VisibilityComponent,
+  GltfContainer,
+})
 
 export function main() {
-  console.log(`Using ${name}@${version}`)
-  initComponents(engine)
-  engine.addSystem(actionsSystem)
-  engine.addSystem(triggersSystem)
+  console.log('Scene ready')
 }

--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -1,0 +1,30 @@
+import { IEngine, PointerEventsSystem } from '@dcl/sdk/ecs'
+import { name, version } from '../package.json'
+import { createComponents, initComponents } from './definitions'
+import { createActionsSystem } from './actions'
+import { createTriggersSystem } from './triggers'
+
+export function initAssetPacks(
+  _engine: any,
+  _pointerEventsSystem: any,
+  components: {
+    Animator: any
+    Transform: any
+    AudioSource: any
+    AvatarAttach: any
+    VisibilityComponent: any
+    GltfContainer: any
+  },
+) {
+  const engine = _engine as IEngine
+  const pointerEventsSystem = _pointerEventsSystem as PointerEventsSystem
+  console.log(`Using ${name}@${version}`)
+  try {
+    createComponents(engine)
+    engine.addSystem(createActionsSystem(engine, components))
+    engine.addSystem(createTriggersSystem(engine, pointerEventsSystem))
+    initComponents(engine)
+  } catch (error) {
+    console.error(`Error initializing Asset Packs: ${(error as Error).message}`)
+  }
+}

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -1,13 +1,12 @@
 import {
-  engine,
+  IEngine,
   Entity,
-  pointerEventsSystem,
+  PointerEventsSystem,
   InputAction,
   LastWriteWinElementSetComponentDefinition,
   DeepReadonlyObject,
 } from '@dcl/sdk/ecs'
 import { triggers, LAYER_1, NO_LAYERS } from '@dcl-sdk/utils'
-import { Actions, Counter, States, Triggers } from './components'
 import {
   Action,
   ComponentName,
@@ -18,6 +17,7 @@ import {
   TriggerConditionType,
   TriggerType,
   getConditionTypesByComponentName,
+  getComponents,
 } from './definitions'
 import { getCurrentValue } from './states'
 import { getActionEvents, getTriggerEvents } from './events'
@@ -26,224 +26,231 @@ import { getPayload } from './action-types'
 const initedEntities = new Set<Entity>()
 const actionQueue: { entity: Entity; action: Action }[] = []
 
-export function triggersSystem(_dt: number) {
-  // process action queue
-  while (actionQueue.length > 0) {
-    const { entity, action } = actionQueue.shift()!
-    const actionEvents = getActionEvents(entity)
-    actionEvents.emit(action.name, getPayload(action))
-  }
-
-  const entitiesWithTriggers = engine.getEntitiesWith(Triggers)
-  for (const [entity, triggers] of entitiesWithTriggers) {
-    if (initedEntities.has(entity)) {
-      continue
+export function createTriggersSystem(
+  engine: IEngine,
+  pointerEventsSystem: PointerEventsSystem,
+) {
+  const { Actions, States, Counter, Triggers } = getComponents(engine)
+  return function triggersSystem(_dt: number) {
+    // process action queue
+    while (actionQueue.length > 0) {
+      const { entity, action } = actionQueue.shift()!
+      const actionEvents = getActionEvents(entity)
+      actionEvents.emit(action.name, getPayload(action))
     }
 
-    // initialize triggers for given entity
-    const types = triggers.value.reduce(
-      (types, trigger) => types.add(trigger.type),
-      new Set<TriggerType>(),
-    )
-    for (const type of types) {
-      switch (type) {
-        case TriggerType.ON_CLICK: {
-          initOnClickTrigger(entity)
-          break
-        }
-        case TriggerType.ON_PLAYER_ENTERS_AREA: 
-        case TriggerType.ON_PLAYER_LEAVES_AREA: {
-          initOnPlayerTriggerArea(entity)
-          break
+    const entitiesWithTriggers = engine.getEntitiesWith(Triggers)
+    for (const [entity, triggers] of entitiesWithTriggers) {
+      if (initedEntities.has(entity)) {
+        continue
+      }
+
+      // initialize triggers for given entity
+      const types = triggers.value.reduce(
+        (types, trigger) => types.add(trigger.type),
+        new Set<TriggerType>(),
+      )
+      for (const type of types) {
+        switch (type) {
+          case TriggerType.ON_CLICK: {
+            initOnClickTrigger(entity)
+            break
+          }
+          case TriggerType.ON_PLAYER_ENTERS_AREA:
+          case TriggerType.ON_PLAYER_LEAVES_AREA: {
+            initOnPlayerTriggerArea(entity)
+            break
+          }
         }
       }
-    }
 
-    // bind triggers
-    const triggerEvents = getTriggerEvents(entity)
-    for (const trigger of triggers.value) {
-      triggerEvents.on(trigger.type, () => {
-        if (checkConditions(trigger)) {
-          for (const triggerAction of trigger.actions) {
-            if (isValidAction(triggerAction)) {
-              const entity = getEntityByAction(triggerAction)
-              if (entity) {
-                const actions = Actions.getOrNull(entity)
-                if (actions) {
-                  const action = actions.value.find(
-                    ($) => $.name === triggerAction.name,
-                  )
-                  if (action) {
-                    // actions are enqueued to be executed on the next tick after all the triggers have been processed,
-                    // this is to avoid one trigger messing with other trigger's conditions
-                    actionQueue.push({ entity, action })
+      // bind triggers
+      const triggerEvents = getTriggerEvents(entity)
+      for (const trigger of triggers.value) {
+        triggerEvents.on(trigger.type, () => {
+          if (checkConditions(trigger)) {
+            for (const triggerAction of trigger.actions) {
+              if (isValidAction(triggerAction)) {
+                const entity = getEntityByAction(triggerAction)
+                if (entity) {
+                  const actions = Actions.getOrNull(entity)
+                  if (actions) {
+                    const action = actions.value.find(
+                      ($) => $.name === triggerAction.name,
+                    )
+                    if (action) {
+                      // actions are enqueued to be executed on the next tick after all the triggers have been processed,
+                      // this is to avoid one trigger messing with other trigger's conditions
+                      actionQueue.push({ entity, action })
+                    }
                   }
                 }
               }
             }
           }
-        }
-      })
-    }
-    triggerEvents.emit(TriggerType.ON_SPAWN)
-
-    initedEntities.add(entity)
-  }
-}
-
-function isValidAction(action: TriggerAction) {
-  const { id, name } = action
-  return !!id && !!name
-}
-
-function checkConditions(trigger: DeepReadonlyObject<Trigger>) {
-  if (trigger.conditions && trigger.conditions.length > 0) {
-    const conditions = trigger.conditions.map(checkCondition)
-    const isTrue = (result?: boolean) => !!result
-    const operation = trigger.operation || TriggerConditionOperation.AND
-    switch (operation) {
-      case TriggerConditionOperation.AND: {
-        return conditions.every(isTrue)
+        })
       }
-      case TriggerConditionOperation.OR: {
-        return conditions.some(isTrue)
-      }
+      triggerEvents.emit(TriggerType.ON_SPAWN)
+
+      initedEntities.add(entity)
     }
   }
-  // if there are no conditions, the trigger can continue
-  return true
-}
 
-function checkCondition(condition: TriggerCondition) {
-  const entity = getEntityByCondition(condition)
-  if (entity) {
-    try {
-      switch (condition.type) {
-        case TriggerConditionType.WHEN_STATE_IS: {
-          const states = States.getOrNull(entity)
-          if (states !== null) {
-            const currentValue = getCurrentValue(states)
-            return currentValue === condition.value
-          }
-          break
+  function isValidAction(action: TriggerAction) {
+    const { id, name } = action
+    return !!id && !!name
+  }
+
+  function checkConditions(trigger: DeepReadonlyObject<Trigger>) {
+    if (trigger.conditions && trigger.conditions.length > 0) {
+      const conditions = trigger.conditions.map(checkCondition)
+      const isTrue = (result?: boolean) => !!result
+      const operation = trigger.operation || TriggerConditionOperation.AND
+      switch (operation) {
+        case TriggerConditionOperation.AND: {
+          return conditions.every(isTrue)
         }
-        case TriggerConditionType.WHEN_STATE_IS_NOT: {
-          const states = States.getOrNull(entity)
-          if (states !== null) {
-            const currentValue = getCurrentValue(states)
-            return currentValue !== condition.value
-          }
-          break
-        }
-        case TriggerConditionType.WHEN_COUNTER_EQUALS: {
-          const counter = Counter.getOrNull(entity)
-          if (counter !== null) {
-            const numeric = Number(condition.value)
-            if (!isNaN(numeric)) {
-              return counter.value === numeric
-            }
-          }
-          break
-        }
-        case TriggerConditionType.WHEN_COUNTER_IS_GREATER_THAN: {
-          const counter = Counter.getOrNull(entity)
-          if (counter !== null) {
-            const numeric = Number(condition.value)
-            if (!isNaN(numeric)) {
-              return counter.value > numeric
-            }
-          }
-          break
-        }
-        case TriggerConditionType.WHEN_COUNTER_IS_LESS_THAN: {
-          const counter = Counter.getOrNull(entity)
-          if (counter !== null) {
-            const numeric = Number(condition.value)
-            if (!isNaN(numeric)) {
-              return counter.value < numeric
-            }
-          }
-          break
+        case TriggerConditionOperation.OR: {
+          return conditions.some(isTrue)
         }
       }
-    } catch (error) {
-      console.error('Error in condition', condition)
     }
+    // if there are no conditions, the trigger can continue
+    return true
   }
-  return false
-}
 
-function getEntityById<T extends { id: number }>(
-  componentName: string,
-  id: number,
-) {
-  const Component = engine.getComponent(
-    componentName,
-  ) as LastWriteWinElementSetComponentDefinition<T>
-  const entities = Array.from(engine.getEntitiesWith(Component))
-  const result = entities.find(([_entity, value]) => value.id === id)
-  return Array.isArray(result) && result.length > 0 ? result[0] : null
-}
-
-function getEntityByAction(action: TriggerAction) {
-  if (action.id) {
-    const entity = getEntityById(ComponentName.ACTIONS, action.id)
+  function checkCondition(condition: TriggerCondition) {
+    const entity = getEntityByCondition(condition)
     if (entity) {
-      return entity
+      try {
+        switch (condition.type) {
+          case TriggerConditionType.WHEN_STATE_IS: {
+            const states = States.getOrNull(entity)
+            if (states !== null) {
+              const currentValue = getCurrentValue(states)
+              return currentValue === condition.value
+            }
+            break
+          }
+          case TriggerConditionType.WHEN_STATE_IS_NOT: {
+            const states = States.getOrNull(entity)
+            if (states !== null) {
+              const currentValue = getCurrentValue(states)
+              return currentValue !== condition.value
+            }
+            break
+          }
+          case TriggerConditionType.WHEN_COUNTER_EQUALS: {
+            const counter = Counter.getOrNull(entity)
+            if (counter !== null) {
+              const numeric = Number(condition.value)
+              if (!isNaN(numeric)) {
+                return counter.value === numeric
+              }
+            }
+            break
+          }
+          case TriggerConditionType.WHEN_COUNTER_IS_GREATER_THAN: {
+            const counter = Counter.getOrNull(entity)
+            if (counter !== null) {
+              const numeric = Number(condition.value)
+              if (!isNaN(numeric)) {
+                return counter.value > numeric
+              }
+            }
+            break
+          }
+          case TriggerConditionType.WHEN_COUNTER_IS_LESS_THAN: {
+            const counter = Counter.getOrNull(entity)
+            if (counter !== null) {
+              const numeric = Number(condition.value)
+              if (!isNaN(numeric)) {
+                return counter.value < numeric
+              }
+            }
+            break
+          }
+        }
+      } catch (error) {
+        console.error('Error in condition', condition)
+      }
     }
+    return false
   }
-  return null
-}
 
-function getEntityByCondition(condition: TriggerCondition) {
-  const componentName = Object.values(ComponentName)
-    .map((componentName) => ({
+  function getEntityById<T extends { id: number }>(
+    componentName: string,
+    id: number,
+  ) {
+    const Component = engine.getComponent(
       componentName,
-      conditionTypes: getConditionTypesByComponentName(componentName),
-    }))
-    .reduce<ComponentName | null>(
-      (result, { componentName, conditionTypes }) =>
-        conditionTypes.includes(condition.type) ? componentName : result,
-      null,
-    )
-  if (componentName && condition.id) {
-    const entity = getEntityById(componentName, condition.id)
-    if (entity) {
-      return entity
-    }
+    ) as LastWriteWinElementSetComponentDefinition<T>
+    const entities = Array.from(engine.getEntitiesWith(Component))
+    const result = entities.find(([_entity, value]) => value.id === id)
+    return Array.isArray(result) && result.length > 0 ? result[0] : null
   }
-  return null
-}
 
-// ON_CLICK
-function initOnClickTrigger(entity: Entity) {
-  pointerEventsSystem.onPointerDown(
-    {
-      entity,
-      opts: {
-        button: InputAction.IA_POINTER,
-        hoverText: 'Click',
+  function getEntityByAction(action: TriggerAction) {
+    if (action.id) {
+      const entity = getEntityById(ComponentName.ACTIONS, action.id)
+      if (entity) {
+        return entity
+      }
+    }
+    return null
+  }
+
+  function getEntityByCondition(condition: TriggerCondition) {
+    const componentName = Object.values(ComponentName)
+      .map((componentName) => ({
+        componentName,
+        conditionTypes: getConditionTypesByComponentName(componentName),
+      }))
+      .reduce<ComponentName | null>(
+        (result, { componentName, conditionTypes }) =>
+          conditionTypes.includes(condition.type) ? componentName : result,
+        null,
+      )
+    if (componentName && condition.id) {
+      const entity = getEntityById(componentName, condition.id)
+      if (entity) {
+        return entity
+      }
+    }
+    return null
+  }
+
+  // ON_CLICK
+  function initOnClickTrigger(entity: Entity) {
+    pointerEventsSystem.onPointerDown(
+      {
+        entity,
+        opts: {
+          button: InputAction.IA_POINTER,
+          hoverText: 'Click',
+        },
       },
-    },
-    () => {
-      const triggerEvents = getTriggerEvents(entity)
-      triggerEvents.emit(TriggerType.ON_CLICK)
-    },
-  )
-}
+      () => {
+        const triggerEvents = getTriggerEvents(entity)
+        triggerEvents.emit(TriggerType.ON_CLICK)
+      },
+    )
+  }
 
-function initOnPlayerTriggerArea(entity: Entity) {
-  triggers.addTrigger(
-    entity, 
-    NO_LAYERS, 
-    LAYER_1, 
-    [{ type: 'box' }], 
-    () => {
-      const triggerEvents = getTriggerEvents(entity)
-      triggerEvents.emit(TriggerType.ON_PLAYER_ENTERS_AREA)
-    }, 
-    () => {
-      const triggerEvents = getTriggerEvents(entity)
-      triggerEvents.emit(TriggerType.ON_PLAYER_LEAVES_AREA)
-    })
+  function initOnPlayerTriggerArea(entity: Entity) {
+    triggers.addTrigger(
+      entity,
+      NO_LAYERS,
+      LAYER_1,
+      [{ type: 'box' }],
+      () => {
+        const triggerEvents = getTriggerEvents(entity)
+        triggerEvents.emit(TriggerType.ON_PLAYER_ENTERS_AREA)
+      },
+      () => {
+        const triggerEvents = getTriggerEvents(entity)
+        triggerEvents.emit(TriggerType.ON_PLAYER_LEAVES_AREA)
+      },
+    )
+  }
 }


### PR DESCRIPTION
This PR adds support for the `@dcl/asset-packs` package from VSCode. Since the `engine` use on VSCode is a different one than the one imported in this package, we needed to pass it from the parent scene, along with the pointerEventsSystem and all the components.

The types of the `initAssetPack` function are all `any` because the types would not match when used on the parent scene, because they come from different node_modules and potentially different versions of the ECS, that's why they have been all set to `any`, to avoid the parent scene having to do that conversion.