### PR TITLE
chore: remove package.json import

### DIFF
--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -1,5 +1,4 @@
 import { IEngine, PointerEventsSystem } from '@dcl/sdk/ecs'
-import { name, version } from '../package.json'
 import { createComponents, initComponents } from './definitions'
 import { createActionsSystem } from './actions'
 import { createTriggersSystem } from './triggers'
@@ -18,7 +17,6 @@ export function initAssetPacks(
 ) {
   const engine = _engine as IEngine
   const pointerEventsSystem = _pointerEventsSystem as PointerEventsSystem
-  console.log(`Using ${name}@${version}`)
   try {
     createComponents(engine)
     engine.addSystem(createActionsSystem(engine, components))


### PR DESCRIPTION
This was removed because at build time the version was always `0.0.0` so the console.log was useless. Also having the package.json in the build cause the dist directory to have another nested src folder.