### PR TITLE
feat: add new categories for smart items

### DIFF
--- a/packs/smart_items/assets/black_button/data.json
+++ b/packs/smart_items/assets/black_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "2e1c4446-c99a-4698-9e13-819d232ca849",
   "name": "Black Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/blue_button/data.json
+++ b/packs/smart_items/assets/blue_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "504cd7ac-2873-40d8-9172-13c9c24304b0",
   "name": "Blue Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/blue_light_button/data.json
+++ b/packs/smart_items/assets/blue_light_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "51ff7609-407f-481d-991b-8449ef59b390",
   "name": "Blue Light Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/button_chest/data.json
+++ b/packs/smart_items/assets/button_chest/data.json
@@ -1,7 +1,7 @@
 {
   "id": "0b8f3b57-a7f3-48aa-a88a-41098f264566",
   "name": "Button Chest",
-  "category": "decorations",
+  "category": "chests",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/chest/data.json
+++ b/packs/smart_items/assets/chest/data.json
@@ -1,7 +1,7 @@
 {
   "id": "dd9fb5a1-7530-4e07-ac3f-3e50572c239f",
   "name": "Chest",
-  "category": "structures",
+  "category": "chests",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/click_area/data.json
+++ b/packs/smart_items/assets/click_area/data.json
@@ -1,7 +1,7 @@
 {
   "id": "846479b0-75d3-450d-bbd6-7e6b3355a7a2",
   "name": "Click Area",
-  "category": "decorations",
+  "category": "utils",
   "tags": ["click", "area"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/cyberpunk_door/data.json
+++ b/packs/smart_items/assets/cyberpunk_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "7cd4d0bc-54d4-4f64-8ab2-6f18f41f03a3",
   "name": "Cyberpunk Door",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/danger_button/data.json
+++ b/packs/smart_items/assets/danger_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "3a93eb8e-b89a-449e-b44e-98e754d9e3cd",
   "name": "Danger Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/fantasy_chest/data.json
+++ b/packs/smart_items/assets/fantasy_chest/data.json
@@ -1,7 +1,7 @@
 {
   "id": "ff9257ec-9d62-404f-97c7-cf19c4035761",
   "name": "Fantasy Chest",
-  "category": "structures",
+  "category": "chests",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/fantasy_lever/data.json
+++ b/packs/smart_items/assets/fantasy_lever/data.json
@@ -1,7 +1,7 @@
 {
   "id": "649d5d96-18be-4f89-b592-f2dfce64b7fe",
   "name": "Fantasy Lever",
-  "category": "decorations",
+  "category": "levers",
   "tags": [
     "lever"
   ],

--- a/packs/smart_items/assets/flying_car_black_horizontal_platform/data.json
+++ b/packs/smart_items/assets/flying_car_black_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "b2d25644-2f43-48c0-a845-6b2220593411",
   "name": "Flying Car Black Horizontal Platform",
-  "category": "vehicles",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "car", "flying", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/flying_car_blue_horizontal_platform/data.json
+++ b/packs/smart_items/assets/flying_car_blue_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f2531b20-80d1-403d-b810-14cab58045a8",
   "name": "Flying Car Blue Horizontal Platform",
-  "category": "decorations",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "car", "flying", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/green_button/data.json
+++ b/packs/smart_items/assets/green_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "76d3a347-02b1-4c74-bbf3-7787ede6a3b1",
   "name": "Green Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/green_light_button/data.json
+++ b/packs/smart_items/assets/green_light_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "43166e90-5f00-4d06-ab07-8cefae85cbd1",
   "name": "Green Light Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/hatch_trapdoor/data.json
+++ b/packs/smart_items/assets/hatch_trapdoor/data.json
@@ -1,7 +1,7 @@
 {
   "id": "fefa3ea5-40f3-46c6-a240-9ce70db8f677",
   "name": "Hatch Trapdoor",
-  "category": "structures",
+  "category": "doors",
   "tags": ["door"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_circular_scifi/data.json
+++ b/packs/smart_items/assets/horizontal_circular_scifi/data.json
@@ -1,7 +1,7 @@
 {
   "id": "03099c99-49ff-4880-9e80-095273bb08f6",
   "name": "Horizontal Circular SciFi",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_circular_scifi_alt/data.json
+++ b/packs/smart_items/assets/horizontal_circular_scifi_alt/data.json
@@ -1,7 +1,7 @@
 {
   "id": "65ce08be-0585-407d-a9ab-df68888263bf",
   "name": "Horizontal Circular SciFi Alt",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_magic_roc/data.json
+++ b/packs/smart_items/assets/horizontal_magic_roc/data.json
@@ -1,7 +1,7 @@
 {
   "id": "57df1075-b4c7-4cbd-8bf0-6c3c1ab1823b",
   "name": "Horizontal Magic Roc",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_magic_roc_alt/data.json
+++ b/packs/smart_items/assets/horizontal_magic_roc_alt/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f584b0d1-317d-4781-8610-527408be21bf",
   "name": "Horizontal Magic Roc Alt",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_platform_genesis/data.json
+++ b/packs/smart_items/assets/horizontal_platform_genesis/data.json
@@ -1,7 +1,7 @@
 {
   "id": "17ac4bbb-6fd5-4c55-a586-b08644a1a059",
   "name": "Horizontal Platform Genesis",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_platform_pirates/data.json
+++ b/packs/smart_items/assets/horizontal_platform_pirates/data.json
@@ -1,7 +1,7 @@
 {
   "id": "9845778b-d877-4c06-a32a-75131a4ca6c4",
   "name": "Horizontal Platform Pirates",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_platform_pirates_alt/data.json
+++ b/packs/smart_items/assets/horizontal_platform_pirates_alt/data.json
@@ -1,7 +1,7 @@
 {
   "id": "d45c2c0e-56b0-433f-8a0b-e80184f25dbd",
   "name": "Horizontal Platform Pirates Alt",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/horizontal_platform_scifi/data.json
+++ b/packs/smart_items/assets/horizontal_platform_scifi/data.json
@@ -1,7 +1,7 @@
 {
   "id": "c5bcfd25-77a5-4186-a1fc-3525a7130daa",
   "name": "Horizontal Platform SciFi",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/iron_fence_door/data.json
+++ b/packs/smart_items/assets/iron_fence_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "e915cdb6-03e6-43e2-81fb-58ad8603f68c",
   "name": "Iron Fence Door",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/metal_trapdoor/data.json
+++ b/packs/smart_items/assets/metal_trapdoor/data.json
@@ -1,7 +1,7 @@
 {
   "id": "1fc96600-3d45-45f6-b364-86aa8cd15587",
   "name": "Metal Trapdoor",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door",
     "trap",

--- a/packs/smart_items/assets/old_wooden_door/data.json
+++ b/packs/smart_items/assets/old_wooden_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "ce058a68-1635-472c-b4b5-4bc9f4b4277f",
   "name": "Old Wooden Door",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/pink_button/data.json
+++ b/packs/smart_items/assets/pink_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "accdfb9c-30e5-483b-8754-1809e1f1e743",
   "name": "Pink Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/pirate_lever/data.json
+++ b/packs/smart_items/assets/pirate_lever/data.json
@@ -1,7 +1,7 @@
 {
   "id": "37e449e5-9298-41b6-8c9a-a6d12b45bdd2",
   "name": "Pirate Lever",
-  "category": "decorations",
+  "category": "levers",
   "tags": [
     "lever"
   ],

--- a/packs/smart_items/assets/raft/data.json
+++ b/packs/smart_items/assets/raft/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f5c1fc52-2cd3-40b2-862a-c6ceaf66aa1e",
   "name": "Raft",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/red_button/data.json
+++ b/packs/smart_items/assets/red_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "89d3e0e7-b9cd-406e-bd95-8abba3b37cc6",
   "name": "Red Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/red_light_button/data.json
+++ b/packs/smart_items/assets/red_light_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6f380825-70bb-42f9-8dce-57563c7ac582",
   "name": "Red Light Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/scifi_chest/data.json
+++ b/packs/smart_items/assets/scifi_chest/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6d694c78-6dd5-4a4d-acee-21dbf67dd464",
   "name": "SciFi Chest",
-  "category": "structures",
+  "category": "chests",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/scifi_lever/data.json
+++ b/packs/smart_items/assets/scifi_lever/data.json
@@ -1,7 +1,7 @@
 {
   "id": "0764e129-9fff-4158-98f0-6db8665dcf7b",
   "name": "SciFi Lever",
-  "category": "decorations",
+  "category": "levers",
   "tags": [
     "lever"
   ],

--- a/packs/smart_items/assets/scifi_lever_console/data.json
+++ b/packs/smart_items/assets/scifi_lever_console/data.json
@@ -1,7 +1,7 @@
 {
   "id": "4bf77c44-42db-4134-90f0-06da4202ff04",
   "name": "SciFi Lever Console",
-  "category": "decorations",
+  "category": "levers",
   "tags": [
     "lever"
   ],

--- a/packs/smart_items/assets/ships_wheel/data.json
+++ b/packs/smart_items/assets/ships_wheel/data.json
@@ -1,7 +1,7 @@
 {
   "id": "bb11e1cf-bed2-4ce8-be37-fe8bf953346d",
   "name": "Ship's Wheel",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/spaceship_blue_horizontal_platform/data.json
+++ b/packs/smart_items/assets/spaceship_blue_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "cca81b2b-24d6-4ef3-aa46-dad27a03d55b",
   "name": "Spaceship Blue Horizontal Platform",
-  "category": "vehicles",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "spaceship", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/spaceship_orange_horizontal_platform/data.json
+++ b/packs/smart_items/assets/spaceship_orange_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "d64291e9-d4a0-4375-9fc3-7f220734b8f1",
   "name": "Spaceship Orange Horizontal Platform",
-  "category": "vehicles",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "spaceship", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/stone_trapdoor/data.json
+++ b/packs/smart_items/assets/stone_trapdoor/data.json
@@ -1,7 +1,7 @@
 {
   "id": "ea5b9544-2ddd-4eba-ba91-41f6cf0b34df",
   "name": "Stone Trapdoor",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door",
     "trap",

--- a/packs/smart_items/assets/taxi_b_horizontal_platform/data.json
+++ b/packs/smart_items/assets/taxi_b_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "7280e965-8938-4759-851f-2bd5b9e8b47b",
   "name": "Taxi B Horizontal Platform",
-  "category": "vehicles",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "taxi", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/taxi_horizontal_platform/data.json
+++ b/packs/smart_items/assets/taxi_horizontal_platform/data.json
@@ -1,7 +1,7 @@
 {
   "id": "8d0cc5fb-6ed7-4452-9524-91f0e88ba77a",
   "name": "Taxi Horizontal Platform",
-  "category": "vehicles",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive", "taxi", "vehicle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/teal_button/data.json
+++ b/packs/smart_items/assets/teal_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6f5c4b28-f27c-4d30-836e-c6fd0b687727",
   "name": "Teal Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],

--- a/packs/smart_items/assets/toggle_button/data.json
+++ b/packs/smart_items/assets/toggle_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "a186416e-81f1-4d0a-b0cd-a4b0077d264d",
   "name": "Toggle Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": ["button", "toggle"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/toy_lever/data.json
+++ b/packs/smart_items/assets/toy_lever/data.json
@@ -1,7 +1,7 @@
 {
   "id": "553f975d-5b42-491f-9788-1a90def3f97c",
   "name": "Toy Lever",
-  "category": "decorations",
+  "category": "levers",
   "tags": [
     "lever"
   ],

--- a/packs/smart_items/assets/trapdoor/data.json
+++ b/packs/smart_items/assets/trapdoor/data.json
@@ -1,7 +1,7 @@
 {
   "id": "4d34d651-8231-4a8f-82bd-d9d3b71505aa",
   "name": "Trapdoor",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door",
     "trap",

--- a/packs/smart_items/assets/treasure_chest/data.json
+++ b/packs/smart_items/assets/treasure_chest/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f8a9d193-46ca-49d5-9c4a-9de3d48eea61",
   "name": "Treasure Chest",
-  "category": "structures",
+  "category": "chests",
   "tags": [
     "door"
   ],

--- a/packs/smart_items/assets/trigger_area/data.json
+++ b/packs/smart_items/assets/trigger_area/data.json
@@ -1,7 +1,7 @@
 {
   "id": "1ab2733f-1782-4521-9eda-6aa8ad684277",
   "name": "Trigger Area",
-  "category": "decorations",
+  "category": "utils",
   "tags": [
     "area",
     "trigger"

--- a/packs/smart_items/assets/turtle/data.json
+++ b/packs/smart_items/assets/turtle/data.json
@@ -1,7 +1,7 @@
 {
   "id": "34bc4fd3-d422-4ffb-b0e5-0fb6a8d0ff8d",
   "name": "Turtle",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "horizontal", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_black_pad/data.json
+++ b/packs/smart_items/assets/vertical_black_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "7abe1ec8-bd5c-4ffe-b318-f17a330296bf",
   "name": "Vertical Black Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_blue_pad/data.json
+++ b/packs/smart_items/assets/vertical_blue_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "c72c3d45-0309-4834-84df-7b5f517694fa",
   "name": "Vertical Blue Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_circular_pl/data.json
+++ b/packs/smart_items/assets/vertical_circular_pl/data.json
@@ -1,7 +1,7 @@
 {
   "id": "c44b9c20-02ab-4974-97e0-78e98ac722f0",
   "name": "Vertical Circular Pl",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_green_pad/data.json
+++ b/packs/smart_items/assets/vertical_green_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6678fa53-038e-4722-b10a-b50cb175436b",
   "name": "Vertical Green Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_hallway_door/data.json
+++ b/packs/smart_items/assets/vertical_hallway_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f7573b6c-f5d3-403c-ad74-2657adbe4a54",
   "name": "Vertical Hallway Door",
-  "category": "structures",
+  "category": "platforms",
   "tags": [
     "door",
     "vertical",

--- a/packs/smart_items/assets/vertical_hallway_door/data.json
+++ b/packs/smart_items/assets/vertical_hallway_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "f7573b6c-f5d3-403c-ad74-2657adbe4a54",
   "name": "Vertical Hallway Door",
-  "category": "platforms",
+  "category": "doors",
   "tags": [
     "door",
     "vertical",

--- a/packs/smart_items/assets/vertical_magic_rock/data.json
+++ b/packs/smart_items/assets/vertical_magic_rock/data.json
@@ -1,7 +1,7 @@
 {
   "id": "4c3b4f56-9329-4230-9d43-4f94fbf6771d",
   "name": "Vertical Magic Rock",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_magic_rock_alt/data.json
+++ b/packs/smart_items/assets/vertical_magic_rock_alt/data.json
@@ -1,7 +1,7 @@
 {
   "id": "132c8f9d-5faa-4e14-b985-44562ccacc24",
   "name": "Vertical Magic Rock Alt",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_platform_genesis/data.json
+++ b/packs/smart_items/assets/vertical_platform_genesis/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6ab20acc-eff6-4272-8243-c183e70a9fa1",
   "name": "Vertical Platform Genesis",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_platform_pirates/data.json
+++ b/packs/smart_items/assets/vertical_platform_pirates/data.json
@@ -1,7 +1,7 @@
 {
   "id": "057c4c5b-87f5-42ab-a6ab-fec09d6a2d75",
   "name": "Vertical Platform Pirates",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_platform_pirates_alt/data.json
+++ b/packs/smart_items/assets/vertical_platform_pirates_alt/data.json
@@ -1,7 +1,7 @@
 {
   "id": "8ccb20e8-8c7c-4aee-9e21-a154bd1b1475",
   "name": "Vertical Platform Pirates Alt",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_platform_scifi/data.json
+++ b/packs/smart_items/assets/vertical_platform_scifi/data.json
@@ -1,7 +1,7 @@
 {
   "id": "58dc566a-2add-4326-b61c-0fdf46903195",
   "name": "Vertical Platform SciFi",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive", "smart"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_purple_pad/data.json
+++ b/packs/smart_items/assets/vertical_purple_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "669b910d-c45c-4712-baa8-7e7e9fde3db2",
   "name": "Vertical Purple Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_red_pad/data.json
+++ b/packs/smart_items/assets/vertical_red_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "534ba1b7-7e5b-4aeb-905a-f155de4b7c6a",
   "name": "Vertical Red Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_white_pad/data.json
+++ b/packs/smart_items/assets/vertical_white_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "ef85eb18-f69c-431c-bcfd-dd51d70a604f",
   "name": "Vertical White Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/vertical_yellow_pad/data.json
+++ b/packs/smart_items/assets/vertical_yellow_pad/data.json
@@ -1,7 +1,7 @@
 {
   "id": "fa423878-fbbe-4333-80a8-3d3f2dbe5889",
   "name": "Vertical Yellow Pad",
-  "category": "structures",
+  "category": "platforms",
   "tags": ["platform", "vertical", "interactive"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/wooden_door/data.json
+++ b/packs/smart_items/assets/wooden_door/data.json
@@ -1,7 +1,7 @@
 {
   "id": "ed36149f-76c5-45c4-a678-d4b31c4ed9ca",
   "name": "Wooden Door",
-  "category": "structures",
+  "category": "doors",
   "tags": ["door"],
   "components": {
     "core::GltfContainer": {

--- a/packs/smart_items/assets/wooden_trapdoor/data.json
+++ b/packs/smart_items/assets/wooden_trapdoor/data.json
@@ -1,7 +1,7 @@
 {
   "id": "6464f5ed-d97d-49fc-9c99-4f9e2069dc71",
   "name": "Wooden Trapdoor",
-  "category": "structures",
+  "category": "doors",
   "tags": [
     "door",
     "trap",

--- a/packs/smart_items/assets/yellow_button/data.json
+++ b/packs/smart_items/assets/yellow_button/data.json
@@ -1,7 +1,7 @@
 {
   "id": "1889bcdc-5608-48fa-9158-b0a56f0afa8b",
   "name": "Yellow Button",
-  "category": "decorations",
+  "category": "buttons",
   "tags": [
     "button"
   ],


### PR DESCRIPTION
Since it was decided to keep the smart items for now in a separete asset pack, I added new categories to better organize them because the current set of categories is not helpful

<img width="1429" alt="Screenshot 2023-10-13 at 11 02 44" src="https://github.com/decentraland/asset-packs/assets/2781777/029eee61-c453-4d4e-8d31-5191bf969028">
