### PR TITLE
fix: clone

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
-        "@dcl/js-runtime": "7.3.29",
-        "@dcl/sdk": "^7.3.29",
+        "@dcl/js-runtime": "7.3.30",
+        "@dcl/sdk": "^7.3.30",
         "mitt": "^3.0.1"
       },
       "devDependencies": {
@@ -860,20 +860,20 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.8.tgz",
-      "integrity": "sha512-DPjkxTsh6wizPc7EjEh5um+ff2o+FE5Fyb8itcpdcznuHXhpyPEU0CF1AN32ikaP3tvKEXd1WGrg5Dr5ewV7kA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.4.2.tgz",
+      "integrity": "sha512-aeqWlOtGuSD9luQqUovgnaKgqjNmioVJjOleS0U/C3R/9+f+XaTCksaHJHoCHydjFJOp29ca32PLmrzaYr88Yw==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
-        "@dcl/js-runtime": "7.3.18",
-        "@dcl/sdk": "^7.3.18",
+        "@dcl/js-runtime": "7.3.29",
+        "@dcl/sdk": "^7.3.29",
         "mitt": "^3.0.1"
       }
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
-      "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
+      "version": "7.3.29",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.29.tgz",
+      "integrity": "sha512-bb1RORbWNURnxphK4wpI3FkhPFb+w3ri9exp39w2H3mkjWfG2YXe0QuMu4oyHE0ERd7ZnFHfaRcjUGsws4hyjQ=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.3.1",
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.29.tgz",
-      "integrity": "sha512-JPX0OiVCqs1BgXHi7wUpXjTlnv0wlOU2VN6BJFDgwbz/cBLDnxkBAZI4/iWXl+mzUY3CMSM9Prt1hfj+NYkhIA=="
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.30.tgz",
+      "integrity": "sha512-SotWwfR9vaF8xewNvuIirnEyWO4YVJyaqHk8nno8ezrhFMdKc+1dfip9kRYbBfBdpX/Os3U6XvOpZdvxpIirmA=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -911,9 +911,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.155192-20231106164658.commit-e3ed246",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.155192-20231106164658.commit-e3ed246.tgz",
-      "integrity": "sha512-BV3WUFjIRd+MvUXVhl+mgO5FI5NCbqv/L+S/DYhlogwJ6E9rjzQXLdwKcbpsK06YovD41kUInvLtmJdgSoREGg=="
+      "version": "1.0.157382-20231204161627.commit-24cc5b6",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.157382-20231204161627.commit-24cc5b6.tgz",
+      "integrity": "sha512-5GDdJ8toIAjjd7xK0NQbIHJFjjwfm/AiBeQC0SvA+fJ8lFzo7aolzg6swDP32wNpNjJrKY0ykEH99YmRsoTH0w=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -921,17 +921,17 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.29.tgz",
-      "integrity": "sha512-Qvs5OkgAOYB2y/VtCNsMnIanCuIoZRldi8h/gG6I52jhyxe7kUfWN4HaJUUwVhFTN8/hDrqxtPEMDeE2GOA2Sw==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.30.tgz",
+      "integrity": "sha512-P4OkS7F6RmCfWsox0kn7JRJLPLC/wjbW/IjIlmzEWFmToSxUaRaZR3weX4AzlExk5lTxSmHwirsrL4pC3ys+Ig==",
       "dependencies": {
-        "@dcl/asset-packs": "^1.2.8"
+        "@dcl/asset-packs": "^1.4.1"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.29.tgz",
-      "integrity": "sha512-bb1RORbWNURnxphK4wpI3FkhPFb+w3ri9exp39w2H3mkjWfG2YXe0QuMu4oyHE0ERd7ZnFHfaRcjUGsws4hyjQ=="
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.30.tgz",
+      "integrity": "sha512-RrzLz3Ak/pE/iJQNr8Jgvcslj11k1pKK9S62pSNKW2MverxeWpIjyM9wKTYY9eoQtfhX7Ch5MsVWXiMgGNXxtg=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.11.0",
@@ -992,11 +992,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.29.tgz",
-      "integrity": "sha512-LWTOxdi88IHnnI8FSjgEjxthMwRdWRV37fwoU8jWp7J/xbVkT2+/Hckrm7yd8Q/tHVmdSSiFcicuMiAA8LxYXQ==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.30.tgz",
+      "integrity": "sha512-pDlo4ybSTotZAhG6goBOgMuTvmKmxikk7WfOitQT0X2LkgblpN5N+oidPsrMVt3F+xpbsCU1FBLBSstGEzOnPg==",
       "dependencies": {
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -1021,28 +1021,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.29.tgz",
-      "integrity": "sha512-6nImr/r036ooT1JDvSvUUYL5K3BpOnkgNWkFE7nwnKKpqiHM9BBr499g9DqbuMEhmzMqQKmaesu8cruj2TYSiA==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.30.tgz",
+      "integrity": "sha512-tB+u4KBhK3llCqpyTxe1Ap+hducGPsZKuJT8OIY4kBChRHaioD8geOcQeVe17xdIhvqRjvIbw4SHJ9Gpel4QYA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.155192-20231106164658.commit-e3ed246",
-        "@dcl/js-runtime": "7.3.29",
-        "@dcl/react-ecs": "7.3.29",
-        "@dcl/sdk-commands": "7.3.29",
+        "@dcl/explorer": "1.0.157382-20231204161627.commit-24cc5b6",
+        "@dcl/js-runtime": "7.3.30",
+        "@dcl/react-ecs": "7.3.30",
+        "@dcl/sdk-commands": "7.3.30",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.29.tgz",
-      "integrity": "sha512-3XR/XCzHWcHpXX8vbWoC0iCwXUs4Rgh3YdGAwiTShZ8Fm4jTVy/pZVQVNW94ijN0s1XJ25ZJqJUMHoc0lqsM+Q==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.30.tgz",
+      "integrity": "sha512-NuUUkE04/CmYC8p6DqudCYlmsM22/Kr8lpt1Gh/KsXXPZsRB6ZKtDTeg+vCFM19W3x/tKzRKW5/sE2SRKwN/rw==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.29",
+        "@dcl/inspector": "7.3.30",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6721819745.commit-dd7b9dc",
@@ -1161,6 +1161,51 @@
         "protoc-gen-dcl_ts_proto": "protoc-gen-dcl_ts_proto"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
@@ -1171,6 +1216,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -1376,28 +1691,29 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
-      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.0.tgz",
+      "integrity": "sha512-rLUv5Se0iDccykxY8bWUuoZT4gg8fNW00zMPqkJN+ONfj5/P1eaGQgygq2EHlR9j20a7tNtp5Y9bZ4rLzViIXQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "dset": "^3.1.2",
         "tslib": "^2.4.1"
       }
     },
     "node_modules/@segment/analytics-generic-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
-      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.0.tgz",
+      "integrity": "sha512-nOgmbfsKD0jFzH3df+PtjLq3qTspdcFpIy/F5ziho5qiE+QATM8wY9TpvCNBbcHr2f3OGzT6SgjJLFlmM5Yb+w=="
     },
     "node_modules/@segment/analytics-node": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
-      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.4.tgz",
+      "integrity": "sha512-yfhWjos0VKrueIhL7NwwaKJTMmDTDPMeNA9nmCZbbIppxWfgfUdqhkSOktQKTUdxLHOygTwuldvayjuftBsRBA==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.2",
-        "@segment/analytics-generic-utils": "1.0.0",
+        "@segment/analytics-core": "1.4.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -3392,9 +3708,9 @@
       }
     },
     "node_modules/eth-connect": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.1.tgz",
-      "integrity": "sha512-RRSOdcfOHHHTAhBVcLiLHiH945/yuwPkmlj59AfLm/ofCmVPRLEqqAONS0xcrLE70OnTHStl7GzHC7Vi3zzfQA=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "node_modules/ethereum-cryptography": {
       "version": "1.2.0",
@@ -5559,9 +5875,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.164.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.164.0.tgz",
-      "integrity": "sha512-yIyMucjcozS7Vxtyy5mH6C8ltbY4gEBVNW4ymZ0kWiKlyMxsvhyUZ63CbxcF7dCKQVjHR+fLJ3SiorfgyhQ+AQ==",
+      "version": "1.165.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.165.0.tgz",
+      "integrity": "sha512-s7+RR/hcCXq8E4jDzwsaq0RXyVpu2pQ4XkT7meBA19xRrHWC32gfwMupcQrnpzoaR7n/F69AvK6FUyW7R+jYZQ==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -5630,9 +5946,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -6753,20 +7069,20 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "@dcl/asset-packs": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.8.tgz",
-      "integrity": "sha512-DPjkxTsh6wizPc7EjEh5um+ff2o+FE5Fyb8itcpdcznuHXhpyPEU0CF1AN32ikaP3tvKEXd1WGrg5Dr5ewV7kA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.4.2.tgz",
+      "integrity": "sha512-aeqWlOtGuSD9luQqUovgnaKgqjNmioVJjOleS0U/C3R/9+f+XaTCksaHJHoCHydjFJOp29ca32PLmrzaYr88Yw==",
       "requires": {
         "@dcl-sdk/utils": "^1.1.3",
-        "@dcl/js-runtime": "7.3.18",
-        "@dcl/sdk": "^7.3.18",
+        "@dcl/js-runtime": "7.3.29",
+        "@dcl/sdk": "^7.3.29",
         "mitt": "^3.0.1"
       },
       "dependencies": {
         "@dcl/js-runtime": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
-          "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
+          "version": "7.3.29",
+          "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.29.tgz",
+          "integrity": "sha512-bb1RORbWNURnxphK4wpI3FkhPFb+w3ri9exp39w2H3mkjWfG2YXe0QuMu4oyHE0ERd7ZnFHfaRcjUGsws4hyjQ=="
         }
       }
     },
@@ -6798,9 +7114,9 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.29.tgz",
-      "integrity": "sha512-JPX0OiVCqs1BgXHi7wUpXjTlnv0wlOU2VN6BJFDgwbz/cBLDnxkBAZI4/iWXl+mzUY3CMSM9Prt1hfj+NYkhIA=="
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.30.tgz",
+      "integrity": "sha512-SotWwfR9vaF8xewNvuIirnEyWO4YVJyaqHk8nno8ezrhFMdKc+1dfip9kRYbBfBdpX/Os3U6XvOpZdvxpIirmA=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.2",
@@ -6808,9 +7124,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "@dcl/explorer": {
-      "version": "1.0.155192-20231106164658.commit-e3ed246",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.155192-20231106164658.commit-e3ed246.tgz",
-      "integrity": "sha512-BV3WUFjIRd+MvUXVhl+mgO5FI5NCbqv/L+S/DYhlogwJ6E9rjzQXLdwKcbpsK06YovD41kUInvLtmJdgSoREGg=="
+      "version": "1.0.157382-20231204161627.commit-24cc5b6",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.157382-20231204161627.commit-24cc5b6.tgz",
+      "integrity": "sha512-5GDdJ8toIAjjd7xK0NQbIHJFjjwfm/AiBeQC0SvA+fJ8lFzo7aolzg6swDP32wNpNjJrKY0ykEH99YmRsoTH0w=="
     },
     "@dcl/hashing": {
       "version": "3.0.4",
@@ -6818,17 +7134,17 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "@dcl/inspector": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.29.tgz",
-      "integrity": "sha512-Qvs5OkgAOYB2y/VtCNsMnIanCuIoZRldi8h/gG6I52jhyxe7kUfWN4HaJUUwVhFTN8/hDrqxtPEMDeE2GOA2Sw==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.30.tgz",
+      "integrity": "sha512-P4OkS7F6RmCfWsox0kn7JRJLPLC/wjbW/IjIlmzEWFmToSxUaRaZR3weX4AzlExk5lTxSmHwirsrL4pC3ys+Ig==",
       "requires": {
-        "@dcl/asset-packs": "^1.2.8"
+        "@dcl/asset-packs": "^1.4.1"
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.29.tgz",
-      "integrity": "sha512-bb1RORbWNURnxphK4wpI3FkhPFb+w3ri9exp39w2H3mkjWfG2YXe0QuMu4oyHE0ERd7ZnFHfaRcjUGsws4hyjQ=="
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.30.tgz",
+      "integrity": "sha512-RrzLz3Ak/pE/iJQNr8Jgvcslj11k1pKK9S62pSNKW2MverxeWpIjyM9wKTYY9eoQtfhX7Ch5MsVWXiMgGNXxtg=="
     },
     "@dcl/linker-dapp": {
       "version": "0.11.0",
@@ -6891,11 +7207,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "@dcl/react-ecs": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.29.tgz",
-      "integrity": "sha512-LWTOxdi88IHnnI8FSjgEjxthMwRdWRV37fwoU8jWp7J/xbVkT2+/Hckrm7yd8Q/tHVmdSSiFcicuMiAA8LxYXQ==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.30.tgz",
+      "integrity": "sha512-pDlo4ybSTotZAhG6goBOgMuTvmKmxikk7WfOitQT0X2LkgblpN5N+oidPsrMVt3F+xpbsCU1FBLBSstGEzOnPg==",
       "requires": {
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -6920,28 +7236,28 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.29.tgz",
-      "integrity": "sha512-6nImr/r036ooT1JDvSvUUYL5K3BpOnkgNWkFE7nwnKKpqiHM9BBr499g9DqbuMEhmzMqQKmaesu8cruj2TYSiA==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.30.tgz",
+      "integrity": "sha512-tB+u4KBhK3llCqpyTxe1Ap+hducGPsZKuJT8OIY4kBChRHaioD8geOcQeVe17xdIhvqRjvIbw4SHJ9Gpel4QYA==",
       "requires": {
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.155192-20231106164658.commit-e3ed246",
-        "@dcl/js-runtime": "7.3.29",
-        "@dcl/react-ecs": "7.3.29",
-        "@dcl/sdk-commands": "7.3.29",
+        "@dcl/explorer": "1.0.157382-20231204161627.commit-24cc5b6",
+        "@dcl/js-runtime": "7.3.30",
+        "@dcl/react-ecs": "7.3.30",
+        "@dcl/sdk-commands": "7.3.30",
         "text-encoding": "0.7.0"
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.3.29",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.29.tgz",
-      "integrity": "sha512-3XR/XCzHWcHpXX8vbWoC0iCwXUs4Rgh3YdGAwiTShZ8Fm4jTVy/pZVQVNW94ijN0s1XJ25ZJqJUMHoc0lqsM+Q==",
+      "version": "7.3.30",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.30.tgz",
+      "integrity": "sha512-NuUUkE04/CmYC8p6DqudCYlmsM22/Kr8lpt1Gh/KsXXPZsRB6ZKtDTeg+vCFM19W3x/tKzRKW5/sE2SRKwN/rw==",
       "requires": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.29",
+        "@dcl/ecs": "7.3.30",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.29",
+        "@dcl/inspector": "7.3.30",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6721819745.commit-dd7b9dc",
@@ -7034,10 +7350,136 @@
         "ts-proto-descriptors": "^1.15.0"
       }
     },
+    "@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "optional": true
+    },
     "@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
       "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "optional": true
     },
     "@fastify/busboy": {
@@ -7195,28 +7637,29 @@
       }
     },
     "@segment/analytics-core": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
-      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.0.tgz",
+      "integrity": "sha512-rLUv5Se0iDccykxY8bWUuoZT4gg8fNW00zMPqkJN+ONfj5/P1eaGQgygq2EHlR9j20a7tNtp5Y9bZ4rLzViIXQ==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "dset": "^3.1.2",
         "tslib": "^2.4.1"
       }
     },
     "@segment/analytics-generic-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
-      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.0.tgz",
+      "integrity": "sha512-nOgmbfsKD0jFzH3df+PtjLq3qTspdcFpIy/F5ziho5qiE+QATM8wY9TpvCNBbcHr2f3OGzT6SgjJLFlmM5Yb+w=="
     },
     "@segment/analytics-node": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
-      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.4.tgz",
+      "integrity": "sha512-yfhWjos0VKrueIhL7NwwaKJTMmDTDPMeNA9nmCZbbIppxWfgfUdqhkSOktQKTUdxLHOygTwuldvayjuftBsRBA==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.2",
-        "@segment/analytics-generic-utils": "1.0.0",
+        "@segment/analytics-core": "1.4.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -8772,9 +9215,9 @@
       "dev": true
     },
     "eth-connect": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.1.tgz",
-      "integrity": "sha512-RRSOdcfOHHHTAhBVcLiLHiH945/yuwPkmlj59AfLm/ofCmVPRLEqqAONS0xcrLE70OnTHStl7GzHC7Vi3zzfQA=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
     },
     "ethereum-cryptography": {
       "version": "1.2.0",
@@ -10407,9 +10850,9 @@
       }
     },
     "ts-proto": {
-      "version": "1.164.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.164.0.tgz",
-      "integrity": "sha512-yIyMucjcozS7Vxtyy5mH6C8ltbY4gEBVNW4ymZ0kWiKlyMxsvhyUZ63CbxcF7dCKQVjHR+fLJ3SiorfgyhQ+AQ==",
+      "version": "1.165.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.165.0.tgz",
+      "integrity": "sha512-s7+RR/hcCXq8E4jDzwsaq0RXyVpu2pQ4XkT7meBA19xRrHWC32gfwMupcQrnpzoaR7n/F69AvK6FUyW7R+jYZQ==",
       "requires": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -10462,9 +10905,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@dcl-sdk/utils": "^1.1.3",
-    "@dcl/js-runtime": "7.3.29",
-    "@dcl/sdk": "^7.3.29",
+    "@dcl/js-runtime": "7.3.30",
+    "@dcl/sdk": "^7.3.30",
     "mitt": "^3.0.1"
   },
   "prettier": {

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,0 +1,61 @@
+import { Entity, IEngine } from '@dcl/sdk/ecs'
+import { getNextId, requiresId } from './id'
+import { isLastWriteWinComponent } from './lww'
+import { TriggersComponent } from './definitions'
+
+export function clone(
+  entity: Entity,
+  engine: IEngine,
+  Triggers: TriggersComponent,
+) {
+  const cloned = engine.addEntity()
+
+  // map ids
+  const newIds = new Map<number, number>()
+  debugger
+  for (const component of engine.componentsIter()) {
+    if (component.has(entity)) {
+      let newValue = JSON.parse(JSON.stringify(component.get(entity)))
+      if (requiresId(component)) {
+        component
+        const oldId = newValue.id
+        const newId = getNextId(engine)
+        newIds.set(oldId, newId)
+        newValue = {
+          ...newValue,
+          id: newId,
+        }
+      }
+      if (isLastWriteWinComponent(component)) {
+        component.createOrReplace(cloned, newValue)
+      }
+    }
+  }
+
+  // if the entity has triggers, remap the old ids in the actions and conditions to the new ones
+  if (Triggers.has(cloned)) {
+    const triggers = Triggers.getMutable(cloned)
+    for (const trigger of triggers.value) {
+      for (const action of trigger.actions) {
+        if (action.id) {
+          const newId = newIds.get(action.id)
+          if (newId) {
+            action.id = newId
+          }
+        }
+      }
+      if (trigger.conditions) {
+        for (const condition of trigger.conditions) {
+          if (condition.id) {
+            const newId = newIds.get(condition.id)
+            if (newId) {
+              condition.id = newId
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return cloned
+}

--- a/src/id.ts
+++ b/src/id.ts
@@ -1,8 +1,15 @@
 import {
+  ComponentDefinition,
   IEngine,
   LastWriteWinElementSetComponentDefinition,
 } from '@dcl/sdk/ecs'
 import { ComponentName, Counter } from './definitions'
+
+export const COMPONENTS_WITH_ID: string[] = [
+  ComponentName.ACTIONS,
+  ComponentName.STATES,
+  ComponentName.COUNTER,
+]
 
 export function getCounterComponent(engine: IEngine) {
   return engine.getComponent(
@@ -14,4 +21,10 @@ export function getNextId(engine: IEngine) {
   const Counter = getCounterComponent(engine)
   const counter = Counter.getOrCreateMutable(engine.RootEntity)
   return ++counter.value
+}
+
+export function requiresId<T extends { id: string }>(
+  component: ComponentDefinition<unknown>,
+): component is ComponentDefinition<T> {
+  return COMPONENTS_WITH_ID.includes(component.componentName)
 }

--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -1,5 +1,9 @@
 import { IEngine, PointerEventsSystem } from '@dcl/sdk/ecs'
-import { createComponents, initComponents } from './definitions'
+import {
+  EngineComponents,
+  createComponents,
+  initComponents,
+} from './definitions'
 import { createActionsSystem } from './actions'
 import { createTriggersSystem } from './triggers'
 import { createTimerSystem } from './timer'
@@ -7,19 +11,11 @@ import { createTimerSystem } from './timer'
 export function initAssetPacks(
   _engine: any,
   _pointerEventsSystem: any,
-  components: {
-    Animator: any
-    Transform: any
-    AudioSource: any
-    AvatarAttach: any
-    VisibilityComponent: any
-    GltfContainer: any
-    Material: any,
-    VideoPlayer: any
-  },
+  _components: Record<keyof EngineComponents, any>,
 ) {
   const engine = _engine as IEngine
   const pointerEventsSystem = _pointerEventsSystem as PointerEventsSystem
+  const components = _components as EngineComponents
   try {
     createComponents(engine)
     engine.addSystem(createActionsSystem(engine, components))


### PR DESCRIPTION
Fixes the issue with the `CLONE_ENTITY` action where no triggers/actions would work on the cloned entity.

It also fixes a runtime issue in the inspector related to the `initVideoPlayerComponents`, because it relied on `VideoPlayer` being available, and it does not exist in the `@dcl/inspector`'s engine.