### PR TITLE
fix: Set Visibility action

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -12,6 +12,7 @@ import {
   PointerFilterMode,
   pointerEventsSystem,
   InputAction,
+  MeshCollider,
 } from '@dcl/sdk/ecs'
 import { Quaternion, Vector3 } from '@dcl/sdk/math'
 import { tweens } from '@dcl-sdk/utils/dist/tween'
@@ -538,12 +539,17 @@ export function createActionsSystem(
     entity: Entity,
     payload: ActionPayload<ActionType.SET_VISIBILITY>,
   ) {
-    const { visible, physicsCollider } = payload
+    const { visible, collider } = payload
     VisibilityComponent.createOrReplace(entity, { visible })
     const gltf = GltfContainer.getMutableOrNull(entity)
+    const meshCollider = MeshCollider.getMutableOrNull(entity)
 
-    if (gltf && physicsCollider !== undefined) {
-      gltf.invisibleMeshesCollisionMask = physicsCollider ? 2 : 0
+    if (collider !== undefined) {
+      if (gltf) {
+        gltf.invisibleMeshesCollisionMask = collider
+      } else if (meshCollider) {
+        meshCollider.collisionMask = collider
+      }
     }
   }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -65,6 +65,8 @@ export const ActionSchemas = {
   [ActionType.STOP_SOUND]: Schemas.Map({}),
   [ActionType.SET_VISIBILITY]: Schemas.Map({
     visible: Schemas.Boolean,
+    /** @deprecated use collider instead */
+    physicsCollider: Schemas.Optional(Schemas.Boolean),
     collider: Schemas.Optional(
       Schemas.EnumNumber(Colliders, Colliders.CL_POINTER),
     ),

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -26,6 +26,7 @@ import {
   TriggerConditionOperation,
   AlignMode,
   Font,
+  Colliders,
 } from './enums'
 
 export * from './enums'
@@ -64,7 +65,9 @@ export const ActionSchemas = {
   [ActionType.STOP_SOUND]: Schemas.Map({}),
   [ActionType.SET_VISIBILITY]: Schemas.Map({
     visible: Schemas.Boolean,
-    physicsCollider: Schemas.Optional(Schemas.Boolean),
+    collider: Schemas.Optional(
+      Schemas.EnumNumber(Colliders, Colliders.CL_POINTER),
+    ),
   }),
   [ActionType.ATTACH_TO_PLAYER]: Schemas.Map({
     anchorPointId: Schemas.Int,

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,4 +1,4 @@
-import { YGAlign, YGJustify } from '@dcl/sdk/ecs'
+import { ColliderLayer, YGAlign, YGJustify } from '@dcl/sdk/ecs'
 
 export enum ComponentName {
   ACTION_TYPES = 'asset-packs::ActionTypes',
@@ -117,4 +117,28 @@ export enum Font {
 export type ScreenAlignMode = {
   alignItems: YGAlign
   justifyContent: YGJustify
+}
+
+// Defined values instead of using from @dcl/ecs because Schemas doesn't support const enums
+export enum Colliders {
+  /** CL_NONE - no collisions */
+  CL_NONE = 0,
+  /** CL_POINTER - collisions with the player's pointer ray (e.g. mouse cursor hovering) */
+  CL_POINTER = 1,
+  /** CL_PHYSICS - collision affecting your player's physics i.e. walls, floor, moving platfroms */
+  CL_PHYSICS = 2,
+  CL_RESERVED1 = 4,
+  CL_RESERVED2 = 8,
+  CL_RESERVED3 = 16,
+  CL_RESERVED4 = 32,
+  CL_RESERVED5 = 64,
+  CL_RESERVED6 = 128,
+  CL_CUSTOM1 = 256,
+  CL_CUSTOM2 = 512,
+  CL_CUSTOM3 = 1024,
+  CL_CUSTOM4 = 2048,
+  CL_CUSTOM5 = 4096,
+  CL_CUSTOM6 = 8192,
+  CL_CUSTOM7 = 16384,
+  CL_CUSTOM8 = 32768,
 }


### PR DESCRIPTION
This PR updates the `Set Visibility` action to set the collision mask for the `MeshRenderer/GLTF` component

Closes: https://github.com/decentraland/sdk/issues/981