### PR TITLE
fix: Play video stream action

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -639,19 +639,15 @@ export function createActionsSystem(
     entity: Entity,
     payload: ActionPayload<ActionType.PLAY_VIDEO_STREAM>,
   ) {
-    // Get the video src from a promise (Video File/Video Stream/DCL Cast)
-    getVideoSrc(payload).then((src) => {
-      if (!src) return
+    const videoSource = VideoPlayer.getMutableOrNull(entity)
+    if (videoSource) {
+      videoSource.playing = true
+    } else {
+      // Get the video src from a promise (Video File/Video Stream/DCL Cast)
+      getVideoSrc(payload).then((src) => {
+        if (!src) return
 
-      const videoSource = VideoPlayer.getMutableOrNull(entity)
-
-      if (videoSource) {
-        videoSource.src = src
-        videoSource.volume = payload.volume ?? 1
-        videoSource.loop = payload.loop ?? false
-        videoSource.playing = true
-      } else {
-        VideoPlayer.createOrReplace(entity, {
+        VideoPlayer.create(entity, {
           src,
           volume: payload.volume ?? 1,
           loop: payload.loop ?? false,
@@ -664,8 +660,8 @@ export function createActionsSystem(
           components,
           Material.getOrNull(entity),
         )
-      }
-    })
+      })
+    }
   }
 
   // STOP_VIDEO

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -640,14 +640,15 @@ export function createActionsSystem(
     payload: ActionPayload<ActionType.PLAY_VIDEO_STREAM>,
   ) {
     const videoSource = VideoPlayer.getMutableOrNull(entity)
-    if (videoSource) {
+
+    if (videoSource && videoSource.src) {
       videoSource.playing = true
     } else {
       // Get the video src from a promise (Video File/Video Stream/DCL Cast)
       getVideoSrc(payload).then((src) => {
         if (!src) return
 
-        VideoPlayer.create(entity, {
+        VideoPlayer.createOrReplace(entity, {
           src,
           volume: payload.volume ?? 1,
           loop: payload.loop ?? false,


### PR DESCRIPTION
This PR fixes the video stream action to set playing a `VideoPlayer` component when it exists or create a new one using the src defined in the payload.