### PR TITLE
fix: Gets readOnly actions instead of mutable elements

### DIFF
--- a/src/action-types.ts
+++ b/src/action-types.ts
@@ -54,7 +54,7 @@ export function getActionTypes(engine: IEngine) {
     ComponentName.ACTION_TYPES,
     engine,
   )
-  const actionTypes = ActionTypes.getOrCreateMutable(engine.RootEntity)
+  const actionTypes = ActionTypes.get(engine.RootEntity)
   return actionTypes.value.map(($) => $.type)
 }
 

--- a/src/action-types.ts
+++ b/src/action-types.ts
@@ -41,7 +41,7 @@ export function getActionSchema<T = unknown>(engine: IEngine, type: string) {
     ComponentName.ACTION_TYPES,
     engine,
   )
-  const actionTypes = ActionTypes.getOrCreateMutable(engine.RootEntity)
+  const actionTypes = ActionTypes.get(engine.RootEntity)
   const actionType = actionTypes.value.find(($) => $.type === type)
   const jsonSchema: JsonSchemaExtended = actionType
     ? JSON.parse(actionType.jsonSchema)


### PR DESCRIPTION
This PR updates the `getActionSchema | getActionTypes` methods to use the `ActionTypes.get` instead of the `ActionTypes.getOrCreateMutable`.

Using the `getOrCreateMutable` causes an undesirable save effect in the inspector project in the DataLayer.