### PR TITLE
fix: use correct Transform component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.6",
-        "@dcl/js-runtime": "7.3.35",
-        "@dcl/sdk": "^7.3.35",
+        "@dcl/js-runtime": "^7.4.2",
+        "@dcl/sdk": "^7.4.2",
         "mitt": "^3.0.1"
       },
       "devDependencies": {
@@ -893,20 +893,20 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.8.0.tgz",
-      "integrity": "sha512-ht7RB36tWZh1KhfrrUIFiq5WT8atTzesuPJ661WvY2LLfjNJXRw4p7jz65GNGw4GRbE7ZZjB++EnX64euElOtA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.0.tgz",
+      "integrity": "sha512-/LUNhvczZcUsUpJg/U4+BQ923Rvzd6XNI8lHQ+F46Y0Ule9Q6HR3vgPR0zdIJAsBvVXDxeDxynidChbscwg80A==",
       "dependencies": {
-        "@dcl-sdk/utils": "^1.1.3",
-        "@dcl/js-runtime": "7.3.30",
-        "@dcl/sdk": "^7.3.30",
+        "@dcl-sdk/utils": "^1.2.6",
+        "@dcl/js-runtime": "7.3.35",
+        "@dcl/sdk": "^7.3.35",
         "mitt": "^3.0.1"
       }
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
-      "version": "7.3.30",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.30.tgz",
-      "integrity": "sha512-RrzLz3Ak/pE/iJQNr8Jgvcslj11k1pKK9S62pSNKW2MverxeWpIjyM9wKTYY9eoQtfhX7Ch5MsVWXiMgGNXxtg=="
+      "version": "7.3.35",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.35.tgz",
+      "integrity": "sha512-KVO0Gglpzu/hQFJBc2o4J7n1s24bYHHnwGetm0NP6wjfrntoKv3ZKGZoJwiMQTvuXIIc+ctYdhXcm/mddxnjHA=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.3.1",
@@ -924,9 +924,9 @@
       }
     },
     "node_modules/@dcl/crypto/node_modules/@dcl/schemas": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.12.0.tgz",
-      "integrity": "sha512-CQjajLNZZCHdL8+c0wujbQ1DEmg4WBfwtQTAHgWEQenujQv4FLaEwFeZ5HOlBU6g7K0OU0qfotl8ArbtiTpfgw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
+      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.36.tgz",
-      "integrity": "sha512-+dKXD1/PX1py6dK5Q2tR4g6vaIPOWbObVy+JRLQ/s37NyoekV5oU9BMAmEJm3LKljSjRIIAlZzF7M4CRUbq0hg=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
+      "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -944,9 +944,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.158673-20240108154501.commit-9c66afc",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.158673-20240108154501.commit-9c66afc.tgz",
-      "integrity": "sha512-FkGYQmjDqviaYBwp6oBzUfXGTMPuEr1srwgjMXv78RjXzRJnFR+Aj0tgqJqSNWHQeGNf+OzuWtKmJO77JTxZoA=="
+      "version": "1.0.160056-20240212151637.commit-33b7e01",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.160056-20240212151637.commit-33b7e01.tgz",
+      "integrity": "sha512-1k/dOHOOaV2k5yTNbWmwlx8OdUEpgUV8dnG4sBwQHtkWcHO/sqNb5YxZ7Ju9j17Opf2tRbt8DJoGYmxArskP0w=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -954,22 +954,23 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.36.tgz",
-      "integrity": "sha512-yzGBdFr8HTiVQ3P4wx0He8D9ZU5bIzF5GM52NvEYnGA3BDhF+UOKaMKIqxOmSS5APYXsDVEjd97TDjeU8QHyPA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.2.tgz",
+      "integrity": "sha512-7W+/jQtd09n4rCs30XTh/TVv0/z+E0IAtZEKo9JIGwiSXctmpZoN9DNfhvICfZJBiAfJfZUzh+KsRCqj1elH+g==",
       "dependencies": {
-        "@dcl/asset-packs": "^1.8.0"
+        "@dcl/asset-packs": "^1.11.0",
+        "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.35",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.35.tgz",
-      "integrity": "sha512-KVO0Gglpzu/hQFJBc2o4J7n1s24bYHHnwGetm0NP6wjfrntoKv3ZKGZoJwiMQTvuXIIc+ctYdhXcm/mddxnjHA=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.2.tgz",
+      "integrity": "sha512-jlmkaLe3lFhCdA8y5+92yKhFhdBoQvoo0GAYLVUqNN8QSSIxAYjO2jmf+fmuM7/mMDVx/ev23PVE1/tzGXJgkg=="
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.11.0.tgz",
-      "integrity": "sha512-5iiQcS5mizxdZ7WKYqOFuaDtDhvOP1Cc92LEQjG60rbzxdP6gWZI3bjlROQukDX/TBplvUq7QsZTTuYtP+hS0g=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.12.0.tgz",
+      "integrity": "sha512-bYxvZ2ljoBuy1KyGugakL9hCRFXjoK55qm40DSfkm5g1o7r2FVEMMVP4e1aSj7IczYrDqp1bibO0+hZF/ddeLg=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -1001,9 +1002,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-7117237552.commit-82dc93b",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-7117237552.commit-82dc93b.tgz",
-      "integrity": "sha512-Ae8LuL/lw1hERuegVuK0OA4rkksaHP5vAl3UjVsUdbGgTgFwDyB8fxe040Rfx3PAllO5jA0nd2oslpqoyDYehA==",
+      "version": "1.0.0-7716486147.commit-7433b10",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-7716486147.commit-7433b10.tgz",
+      "integrity": "sha512-wlFfSR0612R0vJndjjLEwf1wrpVSORDn2rRPxwKenrMZxv+e26ITwB8qA1bxVzcM3/vfJCnZlWgcLrigjlHiGg==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -1025,11 +1026,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.36.tgz",
-      "integrity": "sha512-DHwA19Xl+Tk00CwHUwJnOWB8XwKxtY8Er0ox9iyt5XvkcUml2iZCwWpSUoix/SoQX//BBgOaraVKa+hMvO40OA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.2.tgz",
+      "integrity": "sha512-w16WPk6QzkHbGQU9KC2lu/Uim+ITC1sltvhp4swZgBllpiCJR50h41iR2hRvSPvwao8U3N7Uvk5nMBigRp9Tmw==",
       "dependencies": {
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -1054,31 +1055,31 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.36.tgz",
-      "integrity": "sha512-uN1y890a7dRRVoGu95LpKJW2Wk2SUCFZxztYWPNUT97E799khbVGNRmOs5G+BCRNAaHVAeTTJrdhcrgAXuTz7A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.2.tgz",
+      "integrity": "sha512-LaX9dIlQUuX4xU9vwTTc8034UlxJ8Ix+lJeawFTuAcD1rgMgogefZxUShpjNJZQTKDzad80OVr2VA3r0ecWusg==",
       "dependencies": {
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.158673-20240108154501.commit-9c66afc",
-        "@dcl/js-runtime": "7.3.36",
-        "@dcl/react-ecs": "7.3.36",
-        "@dcl/sdk-commands": "7.3.36",
+        "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
+        "@dcl/js-runtime": "7.4.2",
+        "@dcl/react-ecs": "7.4.2",
+        "@dcl/sdk-commands": "7.4.2",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.36.tgz",
-      "integrity": "sha512-eDgVpz97gwjlDdQA4UkSngs1lxQWLhq+692TYEsQNb1JxW0bQmz9PnibLYjkA0sQxGvHoD2kGtmUsEmK7j5ggQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.2.tgz",
+      "integrity": "sha512-pZ7MvRnMwzfhHA49QWaQsS1CRpVY26zzRkXJ/N9miKlBTY+JoMpcXySK8Bwef5LAWQHXOFQgGy9BNXl1IY+p6A==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.36",
-        "@dcl/linker-dapp": "^0.11.0",
+        "@dcl/inspector": "7.4.2",
+        "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-7117237552.commit-82dc93b",
+        "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -1120,11 +1121,6 @@
         "ipfs-unixfs-importer": "^7.0.3",
         "multiformats": "^9.6.3"
       }
-    },
-    "node_modules/@dcl/sdk/node_modules/@dcl/js-runtime": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.36.tgz",
-      "integrity": "sha512-UE9fpIALZ5QKxgEhqH9/vH7LBX4nQRyc9H6wu0D9ycrxowVn71fzHxvDe1Lr4YDTTLtne9VPet0JEboy5PfEbA=="
     },
     "node_modules/@dcl/ts-proto": {
       "version": "1.154.0",
@@ -3465,9 +3461,9 @@
       }
     },
     "node_modules/dcl-catalyst-client/node_modules/@dcl/schemas": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.12.0.tgz",
-      "integrity": "sha512-CQjajLNZZCHdL8+c0wujbQ1DEmg4WBfwtQTAHgWEQenujQv4FLaEwFeZ5HOlBU6g7K0OU0qfotl8ArbtiTpfgw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
+      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -3993,9 +3989,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "engines": {
         "node": ">= 4"
       }
@@ -5020,9 +5016,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5810,6 +5806,14 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -5860,21 +5864,21 @@
       "dev": true
     },
     "node_modules/ts-poet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
-      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.7.0.tgz",
+      "integrity": "sha512-A0wvFtpkTCWPw7ftTIwbEH+L+7ul4CU0x3jXKQ+kCnmEQIAOwhpUaBmcAYKxZCxHae9/MUl4LbyTqw25BpzW5Q==",
       "dependencies": {
-        "dprint-node": "^1.0.7"
+        "dprint-node": "^1.0.8"
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.166.2",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.166.2.tgz",
-      "integrity": "sha512-ygzeKHZLPbschsqFKmEY1XIJTIIs3k35n3/ZUkz0nF/a/C6x7onITlU7GQBqXmiVPiAvzbT5n/JElrGBVVmvxQ==",
+      "version": "1.167.8",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.167.8.tgz",
+      "integrity": "sha512-HHfwCN7MZgnQ7BhFfeLbg6mZIheqOZ3kGy6/BmBNVVzrk19bCoO6Wkzb5Gb5O7+NmiSd/CBrFh/MnZIoNXEvUw==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
-        "ts-poet": "^6.5.0",
+        "ts-poet": "^6.7.0",
         "ts-proto-descriptors": "1.15.0"
       },
       "bin": {
@@ -5939,9 +5943,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -7113,20 +7117,20 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "@dcl/asset-packs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.8.0.tgz",
-      "integrity": "sha512-ht7RB36tWZh1KhfrrUIFiq5WT8atTzesuPJ661WvY2LLfjNJXRw4p7jz65GNGw4GRbE7ZZjB++EnX64euElOtA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.0.tgz",
+      "integrity": "sha512-/LUNhvczZcUsUpJg/U4+BQ923Rvzd6XNI8lHQ+F46Y0Ule9Q6HR3vgPR0zdIJAsBvVXDxeDxynidChbscwg80A==",
       "requires": {
-        "@dcl-sdk/utils": "^1.1.3",
-        "@dcl/js-runtime": "7.3.30",
-        "@dcl/sdk": "^7.3.30",
+        "@dcl-sdk/utils": "^1.2.6",
+        "@dcl/js-runtime": "7.3.35",
+        "@dcl/sdk": "^7.3.35",
         "mitt": "^3.0.1"
       },
       "dependencies": {
         "@dcl/js-runtime": {
-          "version": "7.3.30",
-          "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.30.tgz",
-          "integrity": "sha512-RrzLz3Ak/pE/iJQNr8Jgvcslj11k1pKK9S62pSNKW2MverxeWpIjyM9wKTYY9eoQtfhX7Ch5MsVWXiMgGNXxtg=="
+          "version": "7.3.35",
+          "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.35.tgz",
+          "integrity": "sha512-KVO0Gglpzu/hQFJBc2o4J7n1s24bYHHnwGetm0NP6wjfrntoKv3ZKGZoJwiMQTvuXIIc+ctYdhXcm/mddxnjHA=="
         }
       }
     },
@@ -7146,9 +7150,9 @@
       },
       "dependencies": {
         "@dcl/schemas": {
-          "version": "9.12.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.12.0.tgz",
-          "integrity": "sha512-CQjajLNZZCHdL8+c0wujbQ1DEmg4WBfwtQTAHgWEQenujQv4FLaEwFeZ5HOlBU6g7K0OU0qfotl8ArbtiTpfgw==",
+          "version": "9.15.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
+          "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
           "requires": {
             "ajv": "^8.11.0",
             "ajv-errors": "^3.0.0",
@@ -7158,9 +7162,9 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.36.tgz",
-      "integrity": "sha512-+dKXD1/PX1py6dK5Q2tR4g6vaIPOWbObVy+JRLQ/s37NyoekV5oU9BMAmEJm3LKljSjRIIAlZzF7M4CRUbq0hg=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
+      "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.2",
@@ -7168,9 +7172,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "@dcl/explorer": {
-      "version": "1.0.158673-20240108154501.commit-9c66afc",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.158673-20240108154501.commit-9c66afc.tgz",
-      "integrity": "sha512-FkGYQmjDqviaYBwp6oBzUfXGTMPuEr1srwgjMXv78RjXzRJnFR+Aj0tgqJqSNWHQeGNf+OzuWtKmJO77JTxZoA=="
+      "version": "1.0.160056-20240212151637.commit-33b7e01",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.160056-20240212151637.commit-33b7e01.tgz",
+      "integrity": "sha512-1k/dOHOOaV2k5yTNbWmwlx8OdUEpgUV8dnG4sBwQHtkWcHO/sqNb5YxZ7Ju9j17Opf2tRbt8DJoGYmxArskP0w=="
     },
     "@dcl/hashing": {
       "version": "3.0.4",
@@ -7178,22 +7182,23 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "@dcl/inspector": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.36.tgz",
-      "integrity": "sha512-yzGBdFr8HTiVQ3P4wx0He8D9ZU5bIzF5GM52NvEYnGA3BDhF+UOKaMKIqxOmSS5APYXsDVEjd97TDjeU8QHyPA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.2.tgz",
+      "integrity": "sha512-7W+/jQtd09n4rCs30XTh/TVv0/z+E0IAtZEKo9JIGwiSXctmpZoN9DNfhvICfZJBiAfJfZUzh+KsRCqj1elH+g==",
       "requires": {
-        "@dcl/asset-packs": "^1.8.0"
+        "@dcl/asset-packs": "^1.11.0",
+        "ts-deepmerge": "^7.0.0"
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.3.35",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.35.tgz",
-      "integrity": "sha512-KVO0Gglpzu/hQFJBc2o4J7n1s24bYHHnwGetm0NP6wjfrntoKv3ZKGZoJwiMQTvuXIIc+ctYdhXcm/mddxnjHA=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.2.tgz",
+      "integrity": "sha512-jlmkaLe3lFhCdA8y5+92yKhFhdBoQvoo0GAYLVUqNN8QSSIxAYjO2jmf+fmuM7/mMDVx/ev23PVE1/tzGXJgkg=="
     },
     "@dcl/linker-dapp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.11.0.tgz",
-      "integrity": "sha512-5iiQcS5mizxdZ7WKYqOFuaDtDhvOP1Cc92LEQjG60rbzxdP6gWZI3bjlROQukDX/TBplvUq7QsZTTuYtP+hS0g=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.12.0.tgz",
+      "integrity": "sha512-bYxvZ2ljoBuy1KyGugakL9hCRFXjoK55qm40DSfkm5g1o7r2FVEMMVP4e1aSj7IczYrDqp1bibO0+hZF/ddeLg=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -7227,9 +7232,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-7117237552.commit-82dc93b",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-7117237552.commit-82dc93b.tgz",
-      "integrity": "sha512-Ae8LuL/lw1hERuegVuK0OA4rkksaHP5vAl3UjVsUdbGgTgFwDyB8fxe040Rfx3PAllO5jA0nd2oslpqoyDYehA==",
+      "version": "1.0.0-7716486147.commit-7433b10",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-7716486147.commit-7433b10.tgz",
+      "integrity": "sha512-wlFfSR0612R0vJndjjLEwf1wrpVSORDn2rRPxwKenrMZxv+e26ITwB8qA1bxVzcM3/vfJCnZlWgcLrigjlHiGg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -7251,11 +7256,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "@dcl/react-ecs": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.36.tgz",
-      "integrity": "sha512-DHwA19Xl+Tk00CwHUwJnOWB8XwKxtY8Er0ox9iyt5XvkcUml2iZCwWpSUoix/SoQX//BBgOaraVKa+hMvO40OA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.2.tgz",
+      "integrity": "sha512-w16WPk6QzkHbGQU9KC2lu/Uim+ITC1sltvhp4swZgBllpiCJR50h41iR2hRvSPvwao8U3N7Uvk5nMBigRp9Tmw==",
       "requires": {
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -7280,38 +7285,31 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.36.tgz",
-      "integrity": "sha512-uN1y890a7dRRVoGu95LpKJW2Wk2SUCFZxztYWPNUT97E799khbVGNRmOs5G+BCRNAaHVAeTTJrdhcrgAXuTz7A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.2.tgz",
+      "integrity": "sha512-LaX9dIlQUuX4xU9vwTTc8034UlxJ8Ix+lJeawFTuAcD1rgMgogefZxUShpjNJZQTKDzad80OVr2VA3r0ecWusg==",
       "requires": {
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.158673-20240108154501.commit-9c66afc",
-        "@dcl/js-runtime": "7.3.36",
-        "@dcl/react-ecs": "7.3.36",
-        "@dcl/sdk-commands": "7.3.36",
+        "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
+        "@dcl/js-runtime": "7.4.2",
+        "@dcl/react-ecs": "7.4.2",
+        "@dcl/sdk-commands": "7.4.2",
         "text-encoding": "0.7.0"
-      },
-      "dependencies": {
-        "@dcl/js-runtime": {
-          "version": "7.3.36",
-          "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.36.tgz",
-          "integrity": "sha512-UE9fpIALZ5QKxgEhqH9/vH7LBX4nQRyc9H6wu0D9ycrxowVn71fzHxvDe1Lr4YDTTLtne9VPet0JEboy5PfEbA=="
-        }
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.3.36",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.36.tgz",
-      "integrity": "sha512-eDgVpz97gwjlDdQA4UkSngs1lxQWLhq+692TYEsQNb1JxW0bQmz9PnibLYjkA0sQxGvHoD2kGtmUsEmK7j5ggQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.2.tgz",
+      "integrity": "sha512-pZ7MvRnMwzfhHA49QWaQsS1CRpVY26zzRkXJ/N9miKlBTY+JoMpcXySK8Bwef5LAWQHXOFQgGy9BNXl1IY+p6A==",
       "requires": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.36",
+        "@dcl/ecs": "7.4.2",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.36",
-        "@dcl/linker-dapp": "^0.11.0",
+        "@dcl/inspector": "7.4.2",
+        "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-7117237552.commit-82dc93b",
+        "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -9081,9 +9079,9 @@
       },
       "dependencies": {
         "@dcl/schemas": {
-          "version": "9.12.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.12.0.tgz",
-          "integrity": "sha512-CQjajLNZZCHdL8+c0wujbQ1DEmg4WBfwtQTAHgWEQenujQv4FLaEwFeZ5HOlBU6g7K0OU0qfotl8ArbtiTpfgw==",
+          "version": "9.15.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
+          "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
           "requires": {
             "ajv": "^8.11.0",
             "ajv-errors": "^3.0.0",
@@ -9459,9 +9457,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -10242,9 +10240,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10848,6 +10846,11 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA=="
+    },
     "ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -10878,21 +10881,21 @@
       }
     },
     "ts-poet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
-      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.7.0.tgz",
+      "integrity": "sha512-A0wvFtpkTCWPw7ftTIwbEH+L+7ul4CU0x3jXKQ+kCnmEQIAOwhpUaBmcAYKxZCxHae9/MUl4LbyTqw25BpzW5Q==",
       "requires": {
-        "dprint-node": "^1.0.7"
+        "dprint-node": "^1.0.8"
       }
     },
     "ts-proto": {
-      "version": "1.166.2",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.166.2.tgz",
-      "integrity": "sha512-ygzeKHZLPbschsqFKmEY1XIJTIIs3k35n3/ZUkz0nF/a/C6x7onITlU7GQBqXmiVPiAvzbT5n/JElrGBVVmvxQ==",
+      "version": "1.167.8",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.167.8.tgz",
+      "integrity": "sha512-HHfwCN7MZgnQ7BhFfeLbg6mZIheqOZ3kGy6/BmBNVVzrk19bCoO6Wkzb5Gb5O7+NmiSd/CBrFh/MnZIoNXEvUw==",
       "requires": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
-        "ts-poet": "^6.5.0",
+        "ts-poet": "^6.7.0",
         "ts-proto-descriptors": "1.15.0"
       }
     },
@@ -10941,9 +10944,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@dcl-sdk/utils": "^1.2.6",
-    "@dcl/js-runtime": "7.3.35",
-    "@dcl/sdk": "^7.3.35",
+    "@dcl/js-runtime": "^7.4.2",
+    "@dcl/sdk": "^7.4.2",
     "mitt": "^3.0.1"
   },
   "prettier": {

--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -19,7 +19,9 @@ export function initAssetPacks(
   try {
     createComponents(engine)
     engine.addSystem(createActionsSystem(engine, components))
-    engine.addSystem(createTriggersSystem(engine, pointerEventsSystem))
+    engine.addSystem(
+      createTriggersSystem(engine, components, pointerEventsSystem),
+    )
     engine.addSystem(createTimerSystem())
     initComponents(engine, components)
   } catch (error) {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -5,7 +5,6 @@ import {
   InputAction,
   LastWriteWinElementSetComponentDefinition,
   DeepReadonlyObject,
-  Transform,
 } from '@dcl/sdk/ecs'
 import { triggers, LAYER_1, NO_LAYERS } from '@dcl-sdk/utils'
 import {
@@ -19,6 +18,7 @@ import {
   TriggerType,
   getConditionTypesByComponentName,
   getComponents,
+  EngineComponents,
 } from './definitions'
 import { getCurrentValue } from './states'
 import { getActionEvents, getTriggerEvents } from './events'
@@ -40,8 +40,10 @@ export function initTriggers(entity: Entity) {
 
 export function createTriggersSystem(
   engine: IEngine,
+  components: EngineComponents,
   pointerEventsSystem: PointerEventsSystem,
 ) {
+  const { Transform } = components
   const { Actions, States, Counter, Triggers } = getComponents(engine)
 
   // save reference to the init function
@@ -261,7 +263,7 @@ export function createTriggersSystem(
   }
 
   function initOnPlayerTriggerArea(entity: Entity) {
-    const { scale } = Transform.get(entity)
+    const transform = Transform.getOrNull(entity)
     triggers.addTrigger(
       entity,
       NO_LAYERS,
@@ -269,7 +271,7 @@ export function createTriggersSystem(
       [
         {
           type: 'box',
-          scale,
+          scale: transform ? transform.scale : { x: 1, y: 1, z: 1 },
         },
       ],
       () => {


### PR DESCRIPTION
This PR fixes the issue where a scene deployed from VSCode would not work with smart items because the Transform component being used was not the one from the scene, but the internal one of the `@dcl/asset-packs` package.

It also added a check to avoid throwing if the entity does not have a transform (should not happen but just in case) and it upgraded the sdk to the latest version.