### PR TITLE
fix: avoid triggering damage on itself of children to prevent infinite loops

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1031,6 +1031,15 @@ export function createActionsSystem(engine: IEngine) {
       const targetPosition = getWorldPosition(target)
       const distance = Vector3.distance(entityPosition, targetPosition)
 
+      // avoid causing damage to the entity itself or its children
+      const entityTree = Array.from(
+        getComponentEntityTree(engine, entity, Transform),
+      )
+      const isPartOfEntityTree = entityTree.some(($) => $ === target)
+      if (isPartOfEntityTree) {
+        continue
+      }
+
       if (layer) {
         if (layer === ProximityLayer.PLAYER) {
           const root = getRoot(target)


### PR DESCRIPTION
If the target entity is the entity itself, or a children, skip the trigger (otherwise this easily ends up in infinite loops, for example when the barrel explodes and triggers the onDamage handler of it's own health bar)