### PR TITLE
feat: Add on input action trigger

### DIFF
--- a/packs/smart_items/assets/fantasy_chest/data.json
+++ b/packs/smart_items/assets/fantasy_chest/data.json
@@ -53,9 +53,14 @@
     "asset-packs::Triggers": {
       "value": [
         {
-          "type": "on_click",
+          "type": "on_input_action",
           "conditions": [],
-          "actions": [],
+          "actions": [
+            {
+              "id": "{self:asset-packs::Actions}",
+              "name": "Open or Close"
+            }
+          ],
           "basicViewId": "trigger-when-clicked"
         },
         {
@@ -166,9 +171,9 @@
     "core::PointerEvents": {
       "pointerEvents": [
         {
-          "eventType": 2,
+          "eventType": 1,
           "eventInfo": {
-            "button": 0,
+            "button": 1,
             "hoverText": "Open / Close",
             "maxDistance": 10,
             "showFeedback": true

--- a/packs/smart_items/assets/fantasy_lever/data.json
+++ b/packs/smart_items/assets/fantasy_lever/data.json
@@ -42,7 +42,7 @@
     "asset-packs::Triggers": {
       "value": [
         {
-          "type": "on_click",
+          "type": "on_input_action",
           "conditions": [
             {
               "id": "{self:asset-packs::States}",
@@ -58,7 +58,7 @@
           ]
         },
         {
-          "type": "on_click",
+          "type": "on_input_action",
           "conditions": [
             {
               "id": "{self:asset-packs::States}",

--- a/packs/smart_items/assets/fantasy_lever/data.json
+++ b/packs/smart_items/assets/fantasy_lever/data.json
@@ -125,10 +125,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource", "asset-packs::States"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Activate / Deactivate",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Lever",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Activated",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/video_player/data.json
+++ b/packs/smart_items/assets/video_player/data.json
@@ -79,10 +79,14 @@
     "asset-packs::Triggers": {
       "value": [
         {
-          "type": "on_click",
+          "type": "on_input_action",
           "conditions": [],
-          "operation": "and",
-          "actions": [],
+          "actions": [
+            {
+              "id": "{self:asset-packs::Actions}",
+              "name": "Plays or Stop"
+            }
+          ],
           "basicViewId": "trigger-when-clicked"
         },
         {
@@ -174,9 +178,9 @@
     "core::PointerEvents": {
       "pointerEvents": [
         {
-          "eventType": 2,
+          "eventType": 1,
           "eventInfo": {
-            "button": 0,
+            "button": 1,
             "hoverText": "Play Video",
             "maxDistance": 10,
             "showFeedback": true

--- a/packs/smart_items/assets/wooden_door/data.json
+++ b/packs/smart_items/assets/wooden_door/data.json
@@ -48,9 +48,14 @@
     "asset-packs::Triggers": {
       "value": [
         {
-          "type": "on_click",
+          "type": "on_input_action",
           "conditions": [],
-          "actions": [],
+          "actions": [
+            {
+              "id": "{self:asset-packs::Actions}",
+              "name": "Open or Close"
+            }
+          ],
           "basicViewId": "trigger-when-clicked"
         },
         {
@@ -152,9 +157,9 @@
     "core::PointerEvents": {
       "pointerEvents": [
         {
-          "eventType": 2,
+          "eventType": 1,
           "eventInfo": {
-            "button": 0,
+            "button": 1,
             "hoverText": "Open / Close",
             "maxDistance": 10,
             "showFeedback": true

--- a/src/components.ts
+++ b/src/components.ts
@@ -15,6 +15,7 @@ import {
   Name as defineName,
   Tween as defineTween,
   TweenSequence as defineTweenSequence,
+  PointerEvents as definePointerEvents,
 } from '@dcl/ecs/dist/components'
 import { IEngine } from '@dcl/sdk/ecs'
 import { EngineComponents } from './definitions'
@@ -37,5 +38,6 @@ export function getExplorerComponents(engine: IEngine): EngineComponents {
     Name: defineName(engine),
     Tween: defineTween(engine),
     TweenSequence: defineTweenSequence(engine),
+    PointerEvents: definePointerEvents(engine),
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -269,7 +269,7 @@ export function createComponents(engine: IEngine) {
       Schemas.Map({
         type: Schemas.EnumString<TriggerType>(
           TriggerType,
-          TriggerType.ON_CLICK,
+          TriggerType.ON_INPUT_ACTION,
         ),
         conditions: Schemas.Optional(
           Schemas.Array(

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -22,6 +22,7 @@ import {
   NameType,
   PBTween,
   PBTweenSequence,
+  PBPointerEvents,
 } from '@dcl/sdk/ecs'
 import { addActionType } from './action-types'
 import {
@@ -292,11 +293,11 @@ export function createComponents(engine: IEngine) {
           Schemas.Map({
             id: Schemas.Optional(Schemas.Int),
             name: Schemas.Optional(Schemas.String),
-            allowedInBasicView: Schemas.Optional(Schemas.Boolean)
+            allowedInBasicView: Schemas.Optional(Schemas.Boolean),
           }),
         ),
         basicViewId: Schemas.Optional(Schemas.String),
-        allowedInBasicView: Schemas.Optional(Schemas.Boolean)
+        allowedInBasicView: Schemas.Optional(Schemas.Boolean),
       }),
     ),
   })
@@ -342,6 +343,7 @@ export type EngineComponents = {
   Name: LastWriteWinElementSetComponentDefinition<NameType>
   Tween: LastWriteWinElementSetComponentDefinition<PBTween>
   TweenSequence: LastWriteWinElementSetComponentDefinition<PBTweenSequence>
+  PointerEvents: LastWriteWinElementSetComponentDefinition<PBPointerEvents>
 }
 
 export function initComponents(engine: IEngine) {
@@ -418,7 +420,7 @@ export function getConditionTypesByComponentName(componentName: ComponentName) {
         TriggerConditionType.WHEN_STATE_IS,
         TriggerConditionType.WHEN_STATE_IS_NOT,
         TriggerConditionType.WHEN_PREVIOUS_STATE_IS,
-        TriggerConditionType.WHEN_PREVIOUS_STATE_IS_NOT
+        TriggerConditionType.WHEN_PREVIOUS_STATE_IS_NOT,
       ]
     }
     case ComponentName.COUNTER: {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -83,6 +83,7 @@ export enum ActionType {
 }
 
 export enum TriggerType {
+  /** @deprecated use ON_INPUT_ACTION instead */
   ON_CLICK = 'on_click',
   ON_INPUT_ACTION = 'on_input_action',
   ON_STATE_CHANGE = 'on_state_change',

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -84,6 +84,7 @@ export enum ActionType {
 
 export enum TriggerType {
   ON_CLICK = 'on_click',
+  ON_INPUT_ACTION = 'on_input_action',
   ON_STATE_CHANGE = 'on_state_change',
   ON_SPAWN = 'on_spawn',
   ON_TWEEN_END = 'on_tween_end',

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -57,7 +57,7 @@ export function createTriggersSystem(
   pointerEventsSystem: PointerEventsSystem,
   tweenSystem: TweenSystem,
 ) {
-  const { Transform, Tween: TweenComponent } = components
+  const { Transform, Tween: TweenComponent, PointerEvents } = components
   const { Actions, States, Counter, Triggers } = getComponents(engine)
 
   // save reference to the init function
@@ -95,6 +95,10 @@ export function createTriggersSystem(
       switch (type) {
         case TriggerType.ON_CLICK: {
           initOnClickTrigger(entity)
+          break
+        }
+        case TriggerType.ON_INPUT_ACTION: {
+          initOnInputActionTrigger(entity)
           break
         }
         case TriggerType.ON_PLAYER_ENTERS_AREA:
@@ -330,6 +334,29 @@ export function createTriggersSystem(
       () => {
         const triggerEvents = getTriggerEvents(entity)
         triggerEvents.emit(TriggerType.ON_CLICK)
+      },
+    )
+  }
+
+  // ON_INPUT_ACTION
+  function initOnInputActionTrigger(entity: Entity) {
+    const pointerEvent = PointerEvents.getOrNull(entity)
+    if (!pointerEvent || pointerEvent.pointerEvents.length === 0) return
+
+    const opts = {
+      button:
+        pointerEvent.pointerEvents[0].eventInfo?.button ||
+        InputAction.IA_POINTER,
+    }
+
+    pointerEventsSystem.onPointerDown(
+      {
+        entity,
+        opts,
+      },
+      () => {
+        const triggerEvents = getTriggerEvents(entity)
+        triggerEvents.emit(TriggerType.ON_INPUT_ACTION)
       },
     )
   }

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -343,12 +343,12 @@ export function createTriggersSystem(
   // ON_INPUT_ACTION
   function initOnInputActionTrigger(entity: Entity) {
     const pointerEvent = PointerEvents.getOrNull(entity)
-    if (!pointerEvent || pointerEvent.pointerEvents.length === 0) return
 
     const opts = {
       button:
-        pointerEvent.pointerEvents[0].eventInfo?.button ||
+        pointerEvent?.pointerEvents[0].eventInfo?.button ||
         InputAction.IA_POINTER,
+      ...(pointerEvent === null ? { hoverText: 'Click' } : {}),
     }
 
     pointerEventsSystem.onPointerDown(

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -93,6 +93,7 @@ export function createTriggersSystem(
     )
     for (const type of types) {
       switch (type) {
+        /** @deprecated use ON_INPUT_ACTION instead */
         case TriggerType.ON_CLICK: {
           initOnClickTrigger(entity)
           break
@@ -321,6 +322,7 @@ export function createTriggersSystem(
     return null
   }
 
+  /** @deprecated use ON_INPUT_ACTION instead */
   // ON_CLICK
   function initOnClickTrigger(entity: Entity) {
     pointerEventsSystem.onPointerDown(


### PR DESCRIPTION
This PR adds a new trigger: `on_input_action`

As the entities can only have one `pointerEventsSystem.onPointerDown`, the trigger `on_click` is marked as deprecated in favor of this new trigger.