### PR TITLE
fix: upgrade @dcl-sdk/utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dcl-sdk/utils": "^1.2.7",
+        "@dcl-sdk/utils": "^1.2.8",
         "@dcl/js-runtime": "7.4.10",
         "@dcl/sdk": "7.4.15",
         "mitt": "^3.0.1"
@@ -888,9 +888,9 @@
       }
     },
     "node_modules/@dcl-sdk/utils": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.2.7.tgz",
-      "integrity": "sha512-sVEBJJ9XcAhI0kb6PLpdgG1a3wGDmc6BYiGyovoHTTh7Iz2IvAPvVRiW5h18X/Q4iB/33wpsAx0OTZ8zA5uiDg=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.2.8.tgz",
+      "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
       "version": "1.16.0",
@@ -7218,9 +7218,9 @@
       }
     },
     "@dcl-sdk/utils": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.2.7.tgz",
-      "integrity": "sha512-sVEBJJ9XcAhI0kb6PLpdgG1a3wGDmc6BYiGyovoHTTh7Iz2IvAPvVRiW5h18X/Q4iB/33wpsAx0OTZ8zA5uiDg=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.2.8.tgz",
+      "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "@dcl/asset-packs": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@dcl-sdk/utils": "^1.2.7",
+    "@dcl-sdk/utils": "^1.2.8",
     "@dcl/js-runtime": "7.4.10",
     "@dcl/sdk": "7.4.15",
     "mitt": "^3.0.1"


### PR DESCRIPTION
This PR upgrades `@dcl-sdk/utils` to `v1.2.8` which [takes into account the new avatar offset](https://github.com/decentraland/sdk7-utils/pull/16).