### PR TITLE
feat: Use primary input action as default for pointer events

### DIFF
--- a/packs/smart_items/assets/black_button/data.json
+++ b/packs/smart_items/assets/black_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/blue_button/data.json
+++ b/packs/smart_items/assets/blue_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/blue_light_button/data.json
+++ b/packs/smart_items/assets/blue_light_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/danger_button/data.json
+++ b/packs/smart_items/assets/danger_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/green_button/data.json
+++ b/packs/smart_items/assets/green_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/green_light_button/data.json
+++ b/packs/smart_items/assets/green_light_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/pink_button/data.json
+++ b/packs/smart_items/assets/pink_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/red_button/data.json
+++ b/packs/smart_items/assets/red_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/red_light_button/data.json
+++ b/packs/smart_items/assets/red_light_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/teal_button/data.json
+++ b/packs/smart_items/assets/teal_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/packs/smart_items/assets/yellow_button/data.json
+++ b/packs/smart_items/assets/yellow_button/data.json
@@ -43,10 +43,27 @@
     "core-schema::Sync-Components": {
       "value": ["core::Animator", "core::AudioSource"]
     },
+    "core::PointerEvents": {
+      "pointerEvents": [
+        {
+          "eventType": 1,
+          "eventInfo": {
+            "button": 1,
+            "hoverText": "Press",
+            "maxDistance": 10,
+            "showFeedback": true
+          }
+        }
+      ]
+    },
     "inspector::Config": {
       "isBasicViewEnabled": true,
       "componentName": "Button",
       "fields": [
+        {
+          "name": "Hover Text",
+          "type": "core::PointerEvents"
+        },
         {
           "name": "When Clicked",
           "type": "asset-packs::Triggers",

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -349,8 +349,8 @@ export function createTriggersSystem(
     const opts = {
       button:
         pointerEvent?.pointerEvents[0].eventInfo?.button ||
-        InputAction.IA_POINTER,
-      ...(pointerEvent === null ? { hoverText: 'Click' } : {}),
+        InputAction.IA_PRIMARY,
+      ...(pointerEvent === null ? { hoverText: 'Press' } : {}),
     }
 
     pointerEventsSystem.onPointerDown(


### PR DESCRIPTION
This PR updates the default `PointerEvent` behavior for the `on_input_action` trigger, setting the button to `primary input` and the hover text to `press`.

Also, add the `PointerEvent` component to the button items.

Closes: https://github.com/decentraland/smart-items/issues/45