### PR TITLE
fix: npm semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@dcl-sdk/utils": "^1.2.8",
-    "@dcl/js-runtime": "7.4.10",
-    "@dcl/sdk": "7.4.15",
+    "@dcl/js-runtime": "^7.4.15",
+    "@dcl/sdk": "^7.4.15",
     "mitt": "^3.0.1"
   },
   "prettier": {


### PR DESCRIPTION
This is to fix the issue elicited with `npm explain @dcl/js-runtime`:
```
@dcl/js-runtime@7.4.10 dev
node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime
  @dcl/js-runtime@"7.4.10" from @dcl/asset-packs@1.19.0
  node_modules/@dcl/asset-packs
    @dcl/asset-packs@"1.19.0" from @dcl/inspector@7.5.1
    node_modules/@dcl/inspector
      @dcl/inspector@"7.5.1" from @dcl/sdk-commands@7.5.1
      node_modules/@dcl/sdk-commands
        @dcl/sdk-commands@"7.5.1" from @dcl/sdk@7.5.1
        node_modules/@dcl/sdk
          dev @dcl/sdk@"7.5.1" from the root project
          @dcl/sdk@"latest" from @dcl/quests-client@1.0.3
          node_modules/@dcl/quests-client
            @dcl/quests-client@"^1.0.3" from @dcl/sdk-commands@7.4.10
            node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands
              @dcl/sdk-commands@"7.4.10" from @dcl/sdk@7.4.10
              node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
                @dcl/sdk@"7.4.10" from @dcl/asset-packs@1.16.0
                node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs
                  @dcl/asset-packs@"^1.14.0" from @dcl/inspector@7.4.10
                  node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
                    @dcl/inspector@"7.4.10" from @dcl/sdk-commands@7.4.10
                  @dcl/asset-packs@"1.16.0" from @dcl/inspector@7.4.15
                  node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
                    @dcl/inspector@"7.4.15" from @dcl/sdk-commands@7.4.15
                    node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands
                      @dcl/sdk-commands@"7.4.15" from @dcl/sdk@7.4.15
                      node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
                        @dcl/sdk@"7.4.15" from @dcl/asset-packs@1.19.0
            @dcl/quests-client@"^1.0.3" from @dcl/sdk-commands@7.4.15
            node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands
              @dcl/sdk-commands@"7.4.15" from @dcl/sdk@7.4.15
              node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
                @dcl/sdk@"7.4.15" from @dcl/asset-packs@1.19.0
            @dcl/quests-client@"^1.0.3" from @dcl/sdk-commands@7.5.1
  @dcl/js-runtime@"7.4.10" from @dcl/asset-packs@1.16.0
  node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs
    @dcl/asset-packs@"^1.14.0" from @dcl/inspector@7.4.10
    node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
      @dcl/inspector@"7.4.10" from @dcl/sdk-commands@7.4.10
    @dcl/asset-packs@"1.16.0" from @dcl/inspector@7.4.15
    node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
      @dcl/inspector@"7.4.15" from @dcl/sdk-commands@7.4.15
      node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands
        @dcl/sdk-commands@"7.4.15" from @dcl/sdk@7.4.15
        node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
          @dcl/sdk@"7.4.15" from @dcl/asset-packs@1.19.0
  @dcl/js-runtime@"7.4.10" from @dcl/sdk@7.4.10
  node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
    @dcl/sdk@"7.4.10" from @dcl/asset-packs@1.16.0
    node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs
      @dcl/asset-packs@"^1.14.0" from @dcl/inspector@7.4.10
      node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
        @dcl/inspector@"7.4.10" from @dcl/sdk-commands@7.4.10
      @dcl/asset-packs@"1.16.0" from @dcl/inspector@7.4.15
      node_modules/@dcl/asset-packs/node_modules/@dcl/inspector
        @dcl/inspector@"7.4.15" from @dcl/sdk-commands@7.4.15
        node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands
          @dcl/sdk-commands@"7.4.15" from @dcl/sdk@7.4.15
          node_modules/@dcl/asset-packs/node_modules/@dcl/sdk
            @dcl/sdk@"7.4.15" from @dcl/asset-packs@1.19.0
```