### PR TITLE
chore: remove peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,6 @@
         "serve-handler": "^6.1.5",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6"
-      },
-      "peerDependencies": {
-        "@dcl/ecs": "7.x"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "@dcl/js-runtime": "7.5.2",
     "mitt": "^3.0.1"
   },
-  "peerDependencies": {
-    "@dcl/ecs": "7.x"
-  },
   "prettier": {
     "singleQuote": true,
     "semi": false,


### PR DESCRIPTION
Remove peer dependency of `@dcl/ecs` to avoid it being installed by npm when installing `@dcl/asset-packs`. This is so users can install a different version of `@dcl/sdk` and the version of `@dcl/ecs` wont clash.