### PR TITLE
fix multiplayer issue when cloning an entity at runtime

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -65,6 +65,7 @@ import {
 } from '@dcl-sdk/utils'
 import { followMap } from './transform'
 import { getEasingFunctionFromInterpolation } from './tweens'
+import { SyncEntitySDK } from './scene-entrypoint'
 
 const initedEntities = new Set<Entity>()
 const uiStacks = new Map<string, Entity>()

--- a/src/components.ts
+++ b/src/components.ts
@@ -16,6 +16,8 @@ import {
   Tween as defineTween,
   TweenSequence as defineTweenSequence,
   PointerEvents as definePointerEvents,
+  NetworkEntity as defineNetworkEntity,
+  SyncComponents as defineSyncComponents
 } from '@dcl/ecs/dist/components'
 import { IEngine } from '@dcl/ecs'
 import { EngineComponents } from './definitions'
@@ -39,5 +41,7 @@ export function getExplorerComponents(engine: IEngine): EngineComponents {
     Tween: defineTween(engine),
     TweenSequence: defineTweenSequence(engine),
     PointerEvents: definePointerEvents(engine),
+    NetworkEntity: defineNetworkEntity(engine),
+    SyncComponents: defineSyncComponents(engine)
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -22,6 +22,8 @@ import {
   PBTween,
   PBTweenSequence,
   PBPointerEvents,
+  NetworkEntity,
+  SyncComponents,
   AudioSourceComponentDefinitionExtended,
 } from '@dcl/ecs'
 import { addActionType } from './action-types'
@@ -343,6 +345,8 @@ export type EngineComponents = {
   Tween: LastWriteWinElementSetComponentDefinition<PBTween>
   TweenSequence: LastWriteWinElementSetComponentDefinition<PBTweenSequence>
   PointerEvents: LastWriteWinElementSetComponentDefinition<PBPointerEvents>
+  NetworkEntity: typeof NetworkEntity
+  SyncComponents: typeof SyncComponents
 }
 
 export function initComponents(engine: IEngine) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { engine } from '@dcl/ecs'
 import { initAssetPacks } from './scene-entrypoint'
 
-initAssetPacks(engine, undefined as any)
+initAssetPacks(engine, {})
 
 export function main() {
   console.log('Scene ready')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { engine } from '@dcl/ecs'
 import { initAssetPacks } from './scene-entrypoint'
 
-initAssetPacks(engine)
+initAssetPacks(engine, undefined as any)
 
 export function main() {
   console.log('Scene ready')

--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -1,4 +1,5 @@
 import {
+  Entity,
   IEngine,
   createInputSystem,
   createPointerEventsSystem,
@@ -13,18 +14,30 @@ import { createTransformSystem } from './transform'
 import { createInputActionSystem } from './input-actions'
 import { createCounterBarSystem } from './counter-bar'
 
+export type ISdkCache = {
+  engine?: IEngine
+  syncEntity?: SyncEntitySDK
+}
+export type SyncEntitySDK =  (entityId: Entity, componentIds: number[], entityEnumId?: number | undefined) => void
+
+export let SdkCache: ISdkCache = {}
+
 let initialized: boolean = false
 /**
  * the _args param is there to mantain backwards compatibility with all versions.
  * Before it was initAssetPacks(engine, pointerEventsSystem, components)
  */
-export function initAssetPacks(_engine: unknown, ..._args: any[]) {
+export function initAssetPacks(_engine: unknown, sdkHelpers: ISdkCache) {
   // Avoid creating the same systems if asset-pack is called more than once
   if (initialized) return
   initialized = true
   // .
 
   const engine = _engine as IEngine
+
+  SdkCache = sdkHelpers
+  SdkCache.engine = engine
+
   try {
     // get engine components
     const components = getEngineComponents(engine)

--- a/src/scene-entrypoint.ts
+++ b/src/scene-entrypoint.ts
@@ -15,28 +15,32 @@ import { createInputActionSystem } from './input-actions'
 import { createCounterBarSystem } from './counter-bar'
 
 export type ISdkCache = {
-  engine?: IEngine
+  // Store the engine to avoid passing the engine to nested functions.
+  engine: IEngine
+  // SyncEntity helper to create network entities at runtime.
   syncEntity?: SyncEntitySDK
 }
 export type SyncEntitySDK =  (entityId: Entity, componentIds: number[], entityEnumId?: number | undefined) => void
 
-export let SdkCache: ISdkCache = {}
+export let SdkCache: ISdkCache
 
 let initialized: boolean = false
 /**
  * the _args param is there to mantain backwards compatibility with all versions.
  * Before it was initAssetPacks(engine, pointerEventsSystem, components)
  */
-export function initAssetPacks(_engine: unknown, sdkHelpers: ISdkCache) {
+export function initAssetPacks(_engine: unknown, sdkHelpers: Omit<ISdkCache, 'engine'>) {
   // Avoid creating the same systems if asset-pack is called more than once
   if (initialized) return
   initialized = true
-  // .
 
   const engine = _engine as IEngine
 
-  SdkCache = sdkHelpers
-  SdkCache.engine = engine
+  SdkCache = { engine }
+
+  if ('syncEntity' in sdkHelpers) {
+    SdkCache = { ...SdkCache, ...sdkHelpers }
+  }
 
   try {
     // get engine components

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -327,13 +327,18 @@ export function createTriggersSystem(
   /** @deprecated use ON_INPUT_ACTION instead */
   // ON_CLICK
   function initOnClickTrigger(entity: Entity) {
+    const pointerEvent = PointerEvents.getOrNull(entity)
+
+    const opts = {
+      button:
+        pointerEvent?.pointerEvents[0].eventInfo?.button ||
+        InputAction.IA_PRIMARY,
+      ...(pointerEvent === null ? { hoverText: 'Click' } : {}),
+    }
     pointerEventsSystem.onPointerDown(
       {
         entity,
-        opts: {
-          button: InputAction.IA_POINTER,
-          hoverText: 'Click',
-        },
+        opts
       },
       () => {
         const triggerEvents = getTriggerEvents(entity)

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -327,18 +327,16 @@ export function createTriggersSystem(
   /** @deprecated use ON_INPUT_ACTION instead */
   // ON_CLICK
   function initOnClickTrigger(entity: Entity) {
-    const pointerEvent = PointerEvents.getOrNull(entity)
+    const pointerEvent = PointerEvents.getMutableOrNull(entity)
 
-    const opts = {
-      button:
-        pointerEvent?.pointerEvents[0].eventInfo?.button ||
-        InputAction.IA_PRIMARY,
-      ...(pointerEvent === null ? { hoverText: 'Click' } : {}),
+    if (pointerEvent) {
+      pointerEvent.pointerEvents = []
     }
+
     pointerEventsSystem.onPointerDown(
       {
         entity,
-        opts
+        opts: { button: InputAction.IA_POINTER, hoverText: 'Click' }
       },
       () => {
         const triggerEvents = getTriggerEvents(entity)

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -328,15 +328,19 @@ export function createTriggersSystem(
   // ON_CLICK
   function initOnClickTrigger(entity: Entity) {
     const pointerEvent = PointerEvents.getMutableOrNull(entity)
+    const opts = { button: InputAction.IA_POINTER, hoverText: 'Click' }
 
     if (pointerEvent) {
-      pointerEvent.pointerEvents = []
+      // Avoid creating duplicats of the same pointerEvent.
+      // This issually happens with entities that are created at runtime and are being syncronized.
+      // If you receive an entity with pointerEvent this function inside the createTriggerSystem is generating another one with the same values.
+      pointerEvent.pointerEvents = pointerEvent.pointerEvents.filter($ => !($.eventInfo?.button === opts.button && $.eventInfo.hoverText === opts.hoverText))
     }
 
     pointerEventsSystem.onPointerDown(
       {
         entity,
-        opts: { button: InputAction.IA_POINTER, hoverText: 'Click' }
+        opts
       },
       () => {
         const triggerEvents = getTriggerEvents(entity)
@@ -347,14 +351,18 @@ export function createTriggersSystem(
 
   // ON_INPUT_ACTION
   function initOnInputActionTrigger(entity: Entity) {
-    const pointerEvent = PointerEvents.getOrNull(entity)
+    const pointerEvent = PointerEvents.getMutableOrNull(entity)
 
     const opts = {
-      button:
-        pointerEvent?.pointerEvents[0].eventInfo?.button ||
-        InputAction.IA_PRIMARY,
-      ...(pointerEvent === null ? { hoverText: 'Press' } : {}),
+      button: InputAction.IA_PRIMARY,
+      hoverText: 'Press'
     }
+
+    if (pointerEvent) {
+      // Avoid creating duplicates of the same pointerEvent.
+      pointerEvent.pointerEvents = pointerEvent.pointerEvents.filter($ => !($.eventInfo?.button === opts.button && $.eventInfo.hoverText === opts.hoverText))
+    }
+
 
     pointerEventsSystem.onPointerDown(
       {


### PR DESCRIPTION
Cloning a Sync Entity at runtime is not working.

The NetworkEntity component has the same values as the parent, so the other clients only sees one entity.

Also generating new entities was adding a new pointer event for each click. So you end up with a stone with N Interact pointer events.

To fix this we expose the syncEntity function to the asset-packs, and when there is a duplicate action, we call this method so the NetworkEntity has the correct values for that entity.

<img width="716" alt="image" src="https://github.com/user-attachments/assets/02374c37-e19e-494f-992b-3a5e3ed64c28">