### PR TITLE
chore: reposition admin tools button

### DIFF
--- a/src/admin-toolkit-ui/index.tsx
+++ b/src/admin-toolkit-ui/index.tsx
@@ -227,7 +227,7 @@ const uiComponent = (
           uiTransform={{
             positionType: 'absolute',
             flexDirection: 'row',
-            position: { top: 80 * scaleFactor, right: 10 * scaleFactor },
+            position: { top: 120 * scaleFactor, right: 10 * scaleFactor },
           }}
         >
           <UiEntity


### PR DESCRIPTION
The Admin Tools button needs to be moved downwards to avoid conflicting with new Explorer Debug Menu on the top right.

## BEFORE (`main`)

<img width="1402" height="789" alt="Screenshot 2025-08-13 at 5 11 35 PM" src="https://github.com/user-attachments/assets/31675f54-c1f3-4134-a464-126c63ff33aa" />

## AFTER (`chore/reposition-admin-tools-button`)

<img width="1310" height="734" alt="Screenshot 2025-08-13 at 6 23 45 PM" src="https://github.com/user-attachments/assets/032b06f1-097e-4923-a7f7-b04248dd9ca3" />
