### PR TITLE
[ENHANCEMENT]: Added output-test.md rendering when DRY script run.

### DIFF
--- a/packs/smart_items/assets/click_area/data.json
+++ b/packs/smart_items/assets/click_area/data.json
@@ -2,8 +2,5 @@
   "id": "846479b0-75d3-450d-bbd6-7e6b3355a7a2",
   "name": "Click Area",
   "category": "utils",
-  "tags": [
-    "click",
-    "area"
-  ]
+  "tags": ["click", "area"]
 }

--- a/packs/smart_items/assets/trigger_area/data.json
+++ b/packs/smart_items/assets/trigger_area/data.json
@@ -2,8 +2,5 @@
   "id": "1ab2733f-1782-4521-9eda-6aa8ad684277",
   "name": "Trigger Area",
   "category": "utils",
-  "tags": [
-    "area",
-    "trigger"
-  ]
+  "tags": ["area", "trigger"]
 }

--- a/src/admin-toolkit-ui/index.tsx
+++ b/src/admin-toolkit-ui/index.tsx
@@ -227,7 +227,7 @@ const uiComponent = (
           uiTransform={{
             positionType: 'absolute',
             flexDirection: 'row',
-            position: { top: 80 * scaleFactor, right: 10 * scaleFactor },
+            position: { top: 120 * scaleFactor, right: 10 * scaleFactor },
           }}
         >
           <UiEntity

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export type AssetData = {
   category: string
   tags: string[]
   composite: AssetComposite
+  description?: string
+  author?: string
 }
 
 export type AssetDataWithoutComposite = Omit<AssetData, 'composite'>


### PR DESCRIPTION
# Problem

If we want to test the performance of the mode, we don't have an easy way of visualizing the results after the run.

# Solution

Add ReadmeGenertor class, that gathers data of the assets being proessed, and generates a report with all the results for evaluation.