### PR TITLE
[ENHANCEMENT]: Add report when running DRY

### DIFF
--- a/test-output.md
+++ b/test-output.md
@@ -10,9 +10,9 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 
 ![Thumbnail](packs/cyberpunk/assets/a_blue/thumbnail.png)   
 
-**Tags**: ['varsity letter', 'intentionals', 'intentional', 'alphabetic characters', 'letter', 'alphabetic character', 'letter of the alphabet', 'varsity letters', 'cleverly designed']
+**Tags**: ['amytal', 'dispirited', 'mere', 'mat', 'first principles', 'new', 'polarities', 'stigmatizations', 'symbolisation', 'angstroms', 'angstrom', 'icon', 'symbolizations', 'sign', 'symbolization', 'flat', 'bodoni fonts', 'stigmatisations', 'type as', 'letter of the alphabet', 'meres', 'abc', 'blue', 'monochrome']
 
-**Description**: The image shows a stylized, three-dimensional letter "A" with a modern and clean design, rendered in a blue color on a black background.
+**Description**: The image displays a three-dimensional model of an alphabet letter 'A' with a modern and clean design, rendered in a teal color against a black background.
 
 
 
@@ -20,9 +20,9 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 
 ![Thumbnail](packs/cyberpunk/assets/a_red/thumbnail.png)   
 
-**Tags**: ['textual matters', 'conceptions', 'a', 'antiophthalmic factor', 'alphabetic characters', 'reddened', 'letter', 'alphabetic character', 'symbolisation', 'blood red', 'symbolization', 'baptistries', 'purposes', 'reddish', 'baptismal font', 'symbol', 'textbook', 'varsity letter', 'school text', 'baptistry', 'red', 'reddishes', 'symbolisations', 'monogram']
+**Tags**: ['ruby', 'rubies', 'bod', 'soft touch', 'first principles', 'soft touches', 'marking', 'material body', 'stop', 'polarities', 'symbolisation', 'angstroms', 'angstrom', 'photographic prints', 'icon', 'symbolizations', 'fibers', 'sign', 'symbolization', 'type as', 'occlusion', 'letter of the alphabet', 'abc', 'material bodies']
 
-**Description**: The image displays a three-dimensional rendering of an abstract letter 'A' with a red outline and a black fill, set against a dark background.
+**Description**: The image displays a three-dimensional red letter "A" with a simple, clean design, set against a black background.
 
 
 
@@ -30,9 +30,9 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 
 ![Thumbnail](packs/cyberpunk/assets/arcade_machine_black/thumbnail.png)   
 
-**Tags**: ['conceptions', 'restraint', 'motorcar', 'ascendencies', 'arcade machine', 'unit of measurement', 'gambling', 'showing', 'nontextual matters', 'gimmick', 'modelling', 'ascendancies', 'automobile', 'car', 'vibration', 'gamblings', 'collectors item', 'vibrations', 'electronic device', 'conception', 'pixel art', 'prowess', 'gimmicks', 'twist']
+**Tags**: ['ascendance', 'video displays', 'retroactive', 'cars', 'retro', 'clitori', 'nontextual matters', 'wholes', 'video game', 'unit of measurement', 'digital display', 'mesas', 'tabular array', 'arcade machine', 'ascendency', 'controls', 'dominances', 'control stick', 'ascendances', 'gamey', 'ex post facto', 'plots', 'time slots', 'boards']
 
-**Description**: The image shows a 3D model of an arcade machine with a screen displaying a game interface and buttons for controls.
+**Description**: The image shows a 3D model of an arcade machine with a monitor displaying a blue screen and two joysticks on either side. It has a gray cabinet with a small window on the front, and there are buttons and a coin slot visible. The machine is set against a black background.
 
 
 
@@ -40,9 +40,9 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 
 ![Thumbnail](packs/cyberpunk/assets/arcade_machine_blue/thumbnail.png)   
 
-**Tags**: ['comptroller', 'gaming unit', 'time slots', 'motorcar', 'display screen', 'covert', 'one armed bandit', 'video game console', 'cabinets', 'loudspeakers', 'loudspeaker', 'arcade machine', 'unit of measurement', 'index numbers', 'button panel', 'cabinet', 'indicant', 'comptrollers', 'expansion slot', 'power indicator', 'whole', 'details', 'talker', 'console table']
+**Tags**: ['video displays', 'cars', 'twists', 'bod', 'material body', 'clitori', 'gimmick', 'video game machine', 'wholes', 'unit of measurement', 'blue cabinet', 'soma', 'coverts', 'twist', 'digital display', 'consoles', 'gimmicks', 'arcade machine', 'silver screens', 'cabinets', 'silver screen', 'bods', 'plastic structure', 'anatomical structure']
 
-**Description**: The image displays a 3D model of an arcade machine with a blue exterior and a clear glass front, featuring a control panel with buttons and joysticks, and a screen displaying what appears to be a game interface with red and green elements.
+**Description**: The image shows a 3D model of an arcade machine with a blue cabinet and a screen displaying game controls. It has a small window on the front and two joysticks on either side. The machine is placed against a black background, highlighting its details.
 
 
 
@@ -50,7 +50,457 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 
 ![Thumbnail](packs/cyberpunk/assets/arcade_machine_green/thumbnail.png)   
 
-**Tags**: ['playthings', 'public figure', 'motorcar', 'theoretical accounts', 'anatomy', 'fig', 'gamy', 'anatomies', 'spunkies', 'arcade game', 'collectable', 'leisure time', 'amusement', 'video displays', 'showing', 'action figure', 'details', 'leisure', 'gimmick', 'modelling', 'automobile', 'model', 'gameys', 'illumination']
+**Tags**: ['video displays', 'comptroller', 'game controller', 'cars', 'retroactive', 'twists', 'retro', 'clitori', 'nontextual matters', 'gimmick', 'video game', 'twist', 'miniature', 'accountants', 'gimmicks', 'digital display', 'arcade machine', 'restrainer', 'cabinets', 'control stick', 'nostalgia', 'gamey', 'ex post facto', 'plots']
 
-**Description**: The image shows a 3D model of an arcade machine with a green top and a blue screen displaying what appears to be a game interface. The machine has two joysticks on the front panel and several buttons around them. It is placed against a black background, emphasizing its design and features.
+**Description**: The image shows a stylized, cartoonish representation of an arcade machine with a green top and a screen displaying what appears to be game controls or a menu. The machine has a red button on the front, and there are two joysticks on either side of the screen. It is placed against a dark background.
+
+
+
+**Asset**: arcade_machine_red
+
+![Thumbnail](packs/cyberpunk/assets/arcade_machine_red/thumbnail.png)   
+
+**Tags**: ['arrangement', 'twists', 'cars', 'shoal', 'flairs', 'clean', 'red and white', 'edward d white', 'cleans', 'ashen', 'fake machine', 'wholes', 'unit of measurement', 'gimmick', 'twist', 'gimmicks', 'organizations', 'shoals', 'arcade machine', 'cabinets', 'entertainment system', 'ashens', 'realnes', 'car']
+
+**Description**: The image shows a 3D model of an arcade game machine with a red cabinet and a small screen displaying what appears to be a video game.
+
+
+
+**Asset**: armchair_a
+
+![Thumbnail](packs/cyberpunk/assets/armchair_a/thumbnail.png)   
+
+**Tags**: ['phone line', 'rail line', 'black and white', 'supreme headquarters allied powers europe', 'bod', 'argumentation', 'material body', 'clean', 'cartoonish', 'edward d white', 'cleans', 'ashen', 'nontextual matters', 'flairs', 'text edition', 'clean lines', 'abstract art', 'schoolbooks', 'modern style', 'minimalistic', 'conceptions', 'argumentations', 'text editions', 'bods']
+
+**Description**: The image shows a 3D model of a white, cylindrical object with two blue rectangles on its sides. It appears to be a simple, abstract design.
+
+
+
+**Asset**: armchair_b
+
+![Thumbnail](packs/cyberpunk/assets/armchair_b/thumbnail.png)   
+
+**Tags**: ['dispirited', 'amytal', 'mere', 'new', 'president', 'miniature', 'formatives', 'charge plates', 'plastic', 'potty', 'animated cartoons', 'canonic', 'toy dog', 'bodoni fonts', 'meres', 'potties', 'chairwomen', 'blue', 'monochrome', 'homochromatic', 'monochromatic', 'simple', 'chair', 'formative']
+
+**Description**: The image shows a stylized blue and white chair with a simple design, presented against a black background.
+
+
+
+**Asset**: armchair_c
+
+![Thumbnail](packs/cyberpunk/assets/armchair_c/thumbnail.png)   
+
+**Tags**: ['mere', 'new', 'president', 'piece of furniture', 'vacuous', 'furniture', 'pinkoes', 'stylish', 'bodoni fonts', 'empty bellieds', 'meres', 'pinkishes', 'chairwomen', 'present days', 'monochrome', 'armrest', 'contemporary', 'monochromatic', 'satiny', 'chair', 'simple', 'shock absorber', 'silken', 'clean']
+
+**Description**: The image shows a modern-looking chair with a sleek design and a pink accent on the backrest. It has a simple yet elegant appearance, featuring a black frame with a white seat cushion. The chair is presented in a 3D rendering style, which gives it a clean and polished look.
+
+
+
+**Asset**: armchair_d
+
+![Thumbnail](packs/cyberpunk/assets/armchair_d/thumbnail.png)   
+
+**Tags**: ['seat', 'mere', 'synopsi', 'mental image', 'new', 'quads', 'president', 'rear ends', 'interpretation', 'hind end', 'piece of furniture', 'vacuous', 'abstract', 'furniture', 'conceptual', 'calculators', 'interlingual renditions', 'bodoni fonts', 'three ds', 'empty bellieds', 'meres', 'multitude', 'chairwomen', 'monochrome']
+
+**Description**: The image shows a 3D model of a chair with a modern design, featuring a curved backrest and armrests. It has a sleek, minimalist aesthetic with a dark color scheme, highlighted by blue accents on the armrests. The chair is presented in a front view, allowing for a clear understanding of its structure and design elements.
+
+
+
+**Asset**: arrow_sign
+
+![Thumbnail](packs/cyberpunk/assets/arrow_sign/thumbnail.png)   
+
+**Tags**: ['mat', 'new', 'corded', 'electronic', 'mouse mats', 'computer mouse', 'accessories', 'production', 'mouse', 'calculators', 'flat', 'cartesian products', 'bodoni fonts', 'intersections', 'twilled', 'compendiou', 'ergonomic', 'pumped ups', 'digital', 'product', 'engineering', 'radio receiver', 'calculator', 'computer']
+
+**Description**: The image shows a simple, white, rectangular object with a single black line on its side, resembling a barcode or a sticker, against a dark background. It appears to be a minimalistic representation of an item or a concept rather than a realistic depiction.
+
+
+
+**Asset**: aston_martin
+
+![Thumbnail](packs/cyberpunk/assets/aston_martin/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'route', 'miniature', 'steering wheel', 'animated cartoons', 'window', 'car', 'fomite', 'toy dog', 'windowpane', 'threshold', 'sofa bed', 'elevator cars', 'bicycle', 'autos', 'f numbers', 'routes', 'blue', 'ascendencies', 'dominance', 'tire', 'convertible', 'exchangeables']
+
+**Description**: The image shows a blue car with a cartoonish design, featuring a character sitting in the driver's seat and another character in the passenger seat. The car has a convertible top down, and there are two small figures resembling people in the backseat. The car is depicted against a black background.
+
+
+
+**Asset**: b_blue
+
+![Thumbnail](packs/cyberpunk/assets/b_blue/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'synopsi', 'new', 'interpretation', '3d rendering', 'stigmatizations', 'hearties', 'abstract', 'regular hexahedron', 'icon', 'straightforwards', 'interlingual renditions', 'bodoni fonts', 'stigmatisations', 'letter of the alphabet', 'solids', 'blue', 'synopsis', 'composition', 'translations', 'emblematic', 'emblematicals', 'missive']
+
+**Description**: The image shows a stylized, three-dimensional graphic of a letter "R" with a blue background. It appears to be a logo or emblem, possibly representing a brand or organization. The "R" is designed in a modern, clean font and is colored in a gradient of light to dark blue, giving it a sense of depth. The overall design is simple yet striking, with the use of negative space around the letter creating an interesting visual effect.
+
+
+
+**Asset**: b_red
+
+![Thumbnail](packs/cyberpunk/assets/b_red/thumbnail.png)   
+
+**Tags**: ['picture', 'mark', 'markings', 'bell ringer', 'logo', 'soft touch', 'soft touches', 'identity', 'branding', 'scheme', 'marking', 'indistinguishabilities', 'vivid', 'varsity letter', 'logotypes', 'stigmatizations', 'monogram', 'identicalnes', 'identity elements', 'missives', 'images', 'symbolisation', 'stigmatization', 'image']
+
+**Description**: The image shows a stylized red letter 'R' with a three-dimensional appearance, set against a black background.
+
+
+
+**Asset**: bar_black
+
+![Thumbnail](packs/cyberpunk/assets/bar_black/thumbnail.png)   
+
+**Tags**: ['memory', 'shinings', 'mere', 'mat', 'new', 'reposition', 'vacuous', 'drearies', 'flat', 'bodoni fonts', 'uprights', 'computer memory', 'empty bellieds', 'meres', 'present days', 'functional', 'upright', 'contemporary', 'satiny', 'simple', 'mats', 'silken', 'storage', 'shelf']
+
+**Description**: The image shows a 3D model of a black metal shelf with multiple shelves and a flat top surface.
+
+
+
+**Asset**: bar_green
+
+![Thumbnail](packs/cyberpunk/assets/bar_green/thumbnail.png)   
+
+**Tags**: ['landing strips', 'mere', 'new', 'electronic', 'signage', 'caterpillar treads', 'atomic number 10', 'heterosexual', 'straightforwards', 'bodoni fonts', 'fluorescent', 'meres', 'firings', 'present days', 'unbent', 'contemporary', 'satiny', 'simple', 'silken', 'rail', 'clean', 'edward d white', 'wide eyeds', 'neon']
+
+**Description**: The image shows a 3D model of a green and black LED strip light with multiple small lights attached to it.
+
+
+
+**Asset**: barrel
+
+![Thumbnail](packs/cyberpunk/assets/barrel/thumbnail.png)   
+
+**Tags**: ['ellen price wood', 'newspaper publisher', 'blast', 'fires', 'swarthines', 'disorganization', 'paper', 'gun barrels', 'rubble', 'nighttime', 'sir henry woods', 'timber', 'jumbles', 'firings', 'encampment', 'forest', 'darkness', 'mares nest', 'composition', 'outside', 'trash', 'themes', 'sir henry wood', 'camping']
+
+**Description**: The image shows a digital rendering of a blue barrel with a fire burning inside, and there are pieces of paper or fabric floating around the flames. The barrel has a rusted appearance and appears to be made of metal. There is a small amount of smoke rising from the fire.
+
+
+
+**Asset**: barrel_black_oil
+
+![Thumbnail](packs/cyberpunk/assets/barrel_black_oil/thumbnail.png)   
+
+**Tags**: ['mere', 'new', 'lamp', 'bodoni fonts', 'medallion', 'meres', 'germ', 'cylinder', 'elucidations', 'present days', 'battery acids', 'functional', 'rootage', 'contemporary', 'simple', 'rootages', 'battery acid', 'clean', 'edward d white', 'wide eyeds', 'dim', 'light source', 'contemporaneou', 'wide eyed']
+
+**Description**: The image shows a black cylindrical object with a red button on top, set against a dark background.
+
+
+
+**Asset**: barrel_no_lid
+
+![Thumbnail](packs/cyberpunk/assets/barrel_no_lid/thumbnail.png)   
+
+**Tags**: ['visual images', 'interpretation', 'light green', '3d rendering', 'well lighteds', 'visual image', 'xanthou', 'tugboat', 'lily livereds', 'drearies', 'visualisation', 'conceptual', 'interlingual renditions', 'igniters', 'tugs', 'light greens', 'tug', 'cylinder', 'virtual', 'constructions', 'engineering', 'translations', 'targets', 'visualisations']
+
+**Description**: The image shows a 3D model of a cylindrical object with a green substance inside and a yellow stripe around its middle. It appears to be a stylized representation of a container or vase, possibly for use in a computer-generated environment.
+
+
+
+**Asset**: barrel_spilled
+
+![Thumbnail](packs/cyberpunk/assets/barrel_spilled/thumbnail.png)   
+
+**Tags**: ['detonating device', 'payloads', 'bursters', 'bearing', 'small arm', 'cap', 'artilleries', 'fall', 'fusee', 'arm', 'weapons systems', 'safety pin', 'fuse', 'payload', 'caps', 'fusees', 'rocket launchers', 'pin numbers', 'burster', 'personal identification numbers', 'twist', 'detonator', 'pieces', 'case']
+
+**Description**: The image shows a 3D model of a cylindrical object with a green light emanating from its top end and a yellow label on its side. It appears to be a stylized representation of a device or component, possibly for use in a digital or virtual environment.
+
+
+
+**Asset**: barrel_with_lid
+
+![Thumbnail](packs/cyberpunk/assets/barrel_with_lid/thumbnail.png)   
+
+**Tags**: ['cylindric', 'streaks', 'supreme headquarters allied powers europe', 'bod', 'material body', 'industrial design', 'canister shots', 'aim', 'eyelid', 'eyelids', 'bands', 'case shots', 'container', 'homes', 'conceptions', 'tins', 'interior department', 'bods', 'simple shape', 'aims', 'band', 'conception', 'tin', 'plans']
+
+**Description**: The image shows a 3D model of a cylindrical container with a lid and a green substance inside. It has a realistic appearance with a dark exterior and a lighter interior. There are yellow stripes on the side of the container, suggesting some sort of branding or identification. The background is black, which contrasts with the object and highlights its details.
+
+
+
+**Asset**: barrel_yellow_oil
+
+![Thumbnail](packs/cyberpunk/assets/barrel_yellow_oil/thumbnail.png)   
+
+**Tags**: ['memory', 'cylindric', 'shinings', 'mere', 'reposition', 'round top', 'formatives', 'eyelids', 'charge plates', 'orangishes', 'vacuous', 'plastic', 'gun barrels', 'commons', 'computer memory', 'coarse', 'tokens', 'hats', 'round tops', 'meres', 'empty bellieds', 'dailies', 'coarses', 'simple']
+
+**Description**: The image displays a three-dimensional rendering of an orange plastic barrel with a black hole on its side.
+
+
+
+**Asset**: basketball_hoop
+
+![Thumbnail](packs/cyberpunk/assets/basketball_hoop/thumbnail.png)   
+
+**Tags**: ['cyberspace', 'basketball hoop', 'net profit', 'black and white basketball hoop', 'basketball hoop in dark room', 'white basketball goal', 'netting on basketball goal', 'red and white logo', 'basketball hoop and net', 'logotypes', 'white backboard of basketball hoop', 'elbow rooms', 'net profits', 'finishes', 'wickets', 'rings', 'ring', 'basketball hoop with logo', 'profits', 'wicket', 'destination', 'baskets', 'cyberspaces', 'basketball hoop in front of logo']
+
+**Description**: The image shows a basketball hoop with a ball inside it against a black background.
+
+
+
+**Asset**: beanbag_blue
+
+![Thumbnail](packs/cyberpunk/assets/beanbag_blue/thumbnail.png)   
+
+**Tags**: ['palm', 'they', 'bluing', 'ball shaped', 'amytal', 'dispirited', 'ball shapeds', 'amytals', 'liquidity', 'hot air', 'globose', 'miniature', 'dented', 'light blue', 'palms', 'dispiriteds', 'smooths', 'latex', 'atmosphere', 'auras', 'melodies', 'liquidnes', 'smooth', 'plaything']
+
+**Description**: The image shows a blue balloon with a crumpled texture, set against a black background.
+
+
+
+**Asset**: beanbag_cream
+
+![Thumbnail](packs/cyberpunk/assets/beanbag_cream/thumbnail.png)   
+
+**Tags**: ['refreshfuls', 'shinings', 'new', 'ripe', 'nutrients', 'yield', 'single', 'advanced', 'xanthou', 'troll', 'lily livereds', 'whole', 'circular', 'round', 'solids', 'garden trucks', 'unanimou', 'food', 'unanimous', 'targets', 'individual', 'circulars', 'lemon', 'smarts']
+
+**Description**: The image depicts a single, yellow, crumpled piece of paper or plastic, which appears to be a simple, three-dimensional object with no additional context or background elements.
+
+
+
+**Asset**: beanbag_navy
+
+![Thumbnail](packs/cyberpunk/assets/beanbag_navy/thumbnail.png)   
+
+**Tags**: ['igniter', 'globs', 'bluing', 'glob', 'circulars', 'light', 'short', 'formative', 'clean', 'moldable', 'glistenings', 'cleans', 'formals', 'ball', 'amytals', 'hollows', 'miniature', 'charge plate', 'brights', 'formatives', 'charge plates', 'dispiriteds', 'empty', 'vacuous']
+
+**Description**: The image shows a blue balloon with a crumpled texture, resembling a deflated or used balloon. It has a shiny surface and appears to have been inflated at some point, as indicated by its uneven shape.
+
+
+
+**Asset**: beanbag_pink
+
+![Thumbnail](packs/cyberpunk/assets/beanbag_pink/thumbnail.png)   
+
+**Tags**: ['folios', 'radicals', 'bod', 'material body', 'interpretation', 'yield', 'text edition', '3d rendering', 'whiles', 'control surfaces', 'no stem', 'smooth texture', 'monochromatic contrast', 'introductions', 'interlingual renditions', 'grains', 'single piece', 'radical', 'tokens', 'single item', 'colorings', 'fores', 'material bodies', 'dividing lines']
+
+**Description**: The image shows a pink, crumpled balloon against a black background.
+
+
+
+**Asset**: bed_gamer
+
+![Thumbnail](packs/cyberpunk/assets/bed_gamer/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'weewee', 'with child', 'electronic', 'device', 'xanthou', 'hearties', 'band', 'lily livereds', 'straightforwards', 'solids', 'blue', 'swimming', 'engineering', 'lap', 'sets', 'swim', 'pocket sizeds', 'targets', 'enceinte', 'clean', 'edward d white', 'twist']
+
+**Description**: The image shows a 3D model of an electronic device with various components such as a battery, circuit board, and a small antenna or sensor on top. It appears to be designed for use in a simulation or animation context.
+
+
+
+**Asset**: big_table
+
+![Thumbnail](packs/cyberpunk/assets/big_table/thumbnail.png)   
+
+**Tags**: ['boozing', 'mere', 'mat', 'table', 'animated cartoons', 'regular hexahedron', 'canonic', 'flat', 'meres', 'monochrome', 'cupful', 'ice cream cone', 'monochromatic', 'drinking', 'simple', 'mats', 'drinkings', 'lack of detail', 'loving cup', 'clean', 'edward d white', 'wide eyeds', 'cartoon', 'retinal cone']
+
+**Description**: The image shows a simple 3D model of a table with a cup on top and a piece of paper underneath, set against a black background.
+
+
+
+**Asset**: big_tube
+
+![Thumbnail](packs/cyberpunk/assets/big_tube/thumbnail.png)   
+
+**Tags**: ['turn of events', 'eddy', 'synopsi', 'bod', 'darknes', 'quads', 'material body', 'optical illusion', 'breaking balls', 'abstract', 'curve', 'drearies', 'geometric shapes', 'igniters', 'shadower', 'magic trick', 'torture', 'reflexions', 'delusion', 'monochrome', 'synopsis', 'material bodies', 'reflexion', 'distortion']
+
+**Description**: The image shows a black and white abstract design resembling a stylized letter 'S'. It appears to be a digital artwork or graphic design with a glossy finish.
+
+
+
+**Asset**: big_tube_emissive
+
+![Thumbnail](packs/cyberpunk/assets/big_tube_emissive/thumbnail.png)   
+
+**Tags**: ['zag', 'unlawfuls', 'synopsi', 'bod', 'optics', 'quads', 'new', 'material body', 'interpretation', 'vacancy', 'argumentations', 'vacuous', 'breaking balls', 'abstract', 'bug', 'curve', 'composite', 'art', 'void', 'formulas', 'futuristic', 'sci fi', 'drearies', 'composites']
+
+**Description**: The image shows a black and white abstract sculpture with a curved form and an orange light source at its base.
+
+
+
+**Asset**: bike_rack
+
+![Thumbnail](packs/cyberpunk/assets/bike_rack/thumbnail.png)   
+
+**Tags**: ['lodgings', 'supplement', 'memory', 'black and white', 'samara', 'reposition', 'formative', 'storage compartments', 'rectangular', 'plastic tray', 'moldable', 'clean', 'edward d white', 'cleans', 'ashen', 'estimator', 'charge plate', 'orthogonals', 'stamp pads', 'lodging', 'formatives', 'key fruit', 'charge plates', 'keyboard']
+
+**Description**: The image shows a 3D model of a set of four metal shelves with a black background.
+
+
+
+**Asset**: billboard_explore_game
+
+![Thumbnail](packs/cyberpunk/assets/billboard_explore_game/thumbnail.png)   
+
+**Tags**: ['pennings', 'spoken language', 'english languages', 'text edition', 'hoardings', 'polarities', 'english language', 'alien', 'fibers', 'sign', 'interlingual renditions', 'extraneous', 'characters', 'standards', 'advertizement', 'ad', 'english people', 'republic of china', 'digital', 'chinaware', 'fibres', 'composition', 'asian', 'asiatic']
+
+**Description**: The image shows a 3D model of an outdoor advertising billboard with Chinese characters on it, standing against a dark background.
+
+
+
+**Asset**: black_pad
+
+![Thumbnail](packs/cyberpunk/assets/black_pad/thumbnail.png)   
+
+**Tags**: ['plates', 'no light source', 'bod', 'material body', 'text edition', 'context of use', 'legal actions', 'no sound', 'band', 'plate', 'no interaction', 'no scale', 'apparent motions', 'grains', 'activity', 'reflexions', 'tokens', 'germ', 'multitude', 'colorings', 'single object', 'level headeds', 'material bodies', 'reflexion']
+
+**Description**: The image shows a black circular object with a glossy surface, set against a dark background. It appears to be a simple, stylized representation of a pizza or doughnut, given its shape and color. There are no visible texts or additional elements in the image.
+
+
+
+**Asset**: bottle_sake
+
+![Thumbnail](packs/cyberpunk/assets/bottle_sake/thumbnail.png)   
+
+**Tags**: ['piston chambers', 'fluidness', 'boozing', 'runniness', 'usage', 'nursing bottles', 'drink', 'formative', 'feeding bottles', 'liquidity', 'moldable', 'detonating device', 'disposable', 'pitch blackness', 'pitch blacknes', 'pileu', 'urine', 'charge plate', 'textiles', 'smutty', 'dim', 'formatives', 'bottleful', 'container']
+
+**Description**: The image shows a black bottle with a white label and a silver cap. The bottle has a textured surface and appears to be made of plastic or metal. It is set against a dark background.
+
+
+
+**Asset**: box
+
+![Thumbnail](packs/cyberpunk/assets/box/thumbnail.png)   
+
+**Tags**: ['new', 'rectangular', 'chain armour', 'unmoveds', 'mail services', 'despatch', 'orthogonals', 'certains', 'software package', 'untouched', 'production', 'cartesian products', 'unlifelikes', 'ladings', 'intersections', 'turgid', 'unopened', 'packet', 'delivery', 'composition boards', 'merchant marines', 'untasteds', 'product', 'dark brown']
+
+**Description**: The image shows a brown cardboard box with a white label on its side.
+
+
+
+**Asset**: building_decor_02
+
+![Thumbnail](packs/cyberpunk/assets/building_decor_02/thumbnail.png)   
+
+**Tags**: ['mental image', 'mat', 'bod', 'material body', 'rectangular', 'text edition', 'orthogonals', 'control surfaces', 'gray object', 'flat background', 'argumentations', 'flat', 'black and white image', 'declaration', 'colorings', 'monochrome', 'material bodies', 'no depth', 'homochromatic', 'result', 'profundity', 'monochromatic', 'targets', 'mats']
+
+**Description**: The image shows a simple, gray 3D model that appears to be a long, rectangular object with a flat top and bottom, and a straight line running down its center. It has no visible textures or details, suggesting it is a basic shape without any additional features or decorations. The style of the image is minimalistic and abstract, focusing on the geometric form of the object rather than any realistic or detailed representation.
+
+
+
+**Asset**: building_decor_03
+
+![Thumbnail](packs/cyberpunk/assets/building_decor_03/thumbnail.png)   
+
+**Tags**: ['mere', 'synopsi', 'light', 'new', 'mat', 'clean', 'edward d white', 'cleans', 'wide eyeds', 'ashen', 'flat tire', 'categoric', 'black and white', 'vivid', 'rectangular prism', 'nonobjectives', 'forward lookings', 'minimalistic', 'fair', 'abstract', 'lifelike', 'minimalist', 'optical prism', 'wide eyed']
+
+**Description**: The image displays a simple, white, rectangular block with a flat top and bottom, set against a black background.
+
+
+
+**Asset**: bulletin_post
+
+![Thumbnail](packs/cyberpunk/assets/bulletin_post/thumbnail.png)   
+
+**Tags**: ['new', 'newspaper publisher', 'colourfuls', 'unequaled', 'paper', 'lamp', 'bodoni fonts', 'igniters', 'paperweight', 'lightbulbs', 'elucidations', 'present days', 'contemporary', 'composition', 'methamphetamine hydrochlorides', 'igniter', 'originatives', 'short', 'clean', 'themes', 'cosmetics', 'coloureds', 'contemporaneou', 'singulars']
+
+**Description**: The image shows a 3D rendering of a modern-looking lamp with a sleek design and a colorful light effect. It has a black base with a blue and green light pattern, and there are sticky notes attached to its side. The lamp is set against a dark background, emphasizing its features.
+
+
+
+**Asset**: bus
+
+![Thumbnail](packs/cyberpunk/assets/bus/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'jalopies', 'metropoli', 'light green', 'xanthou', 'animated cartoons', 'locomotion', 'icon', 'lily livereds', 'transmitter', 'fomite', 'transportation', 'turgid', 'light greens', 'blue', 'urban center', 'locomotions', 'pocket sizeds', 'urban', 'passenger vehicle', 'picture', 'enceinte', 'travel']
+
+**Description**: The image shows a stylized, colorful 3D model of a bus with a vibrant blue and green exterior, set against a black background. It appears to be a cartoon-like representation, possibly for use in video games or other digital media. The bus is depicted from the side, showcasing its length and design features such as windows and a roof rack.
+
+
+
+**Asset**: bus_stop
+
+![Thumbnail](packs/cyberpunk/assets/bus_stop/thumbnail.png)   
+
+**Tags**: ['power', 'bod', 'material body', 'quads', 'storeys', 'president', 'piece of furniture', 'table', 'furniture', 'desk', 'area', 'frame up', 'trading floors', 'colorings', 'chairwomen', 'work benches', 'work bench', 'role', 'material bodies', 'elbow room', 'quad', 'chair', 'bench', 'layout']
+
+**Description**: The image depicts a simple 3D model of an office setup, including a desk with a monitor and keyboard, a chair, and a floor plan layout. It appears to be a stylized representation, possibly for use in a video game or as part of a design mockup.
+
+
+
+**Asset**: buy
+
+![Thumbnail](packs/cyberpunk/assets/buy/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'synopsi', 'new', 'interpretation', 'miniature', '3d rendering', 'formatives', 'charge plates', 'colourfuls', 'abstract', 'plastic', 'skyscraper', 'styliseds', 'interlingual renditions', 'toy dog', 'bodoni fonts', 'statuettes', 'geometricals', 'blue', 'monochrome', 'synopsis', 'constructions', 'monochromatic']
+
+**Description**: The image shows a blue 3D model of an abstract structure that resembles a stylized letter 'T' with two vertical bars connected by a horizontal bar. The background is black, emphasizing the object.
+
+
+
+**Asset**: c_blue
+
+![Thumbnail](packs/cyberpunk/assets/c_blue/thumbnail.png)   
+
+**Tags**: ['amytal', 'dispirited', 'samara', 'fixing', 'symbolisation', 'hexangular', 'icon', 'symbolizations', 'symbolization', 'fastenings', 'thunderbolt', 'bolt of lightning', 'tokens', 'blue', 'dick', 'targets', 'hardware', 'picture', 'twist', 'fastener', 'pulls', 'centrals', 'item', 'dispiriteds']
+
+**Description**: The image displays a stylized, three-dimensional rendering of a wrench with a blue handle and a silver head, set against a black background.
+
+
+
+**Asset**: c_red
+
+![Thumbnail](packs/cyberpunk/assets/c_red/thumbnail.png)   
+
+**Tags**: ['picture', 'supreme headquarters allied powers europe', 'bod', 'material body', 'figure of speech', 'nontextual matters', 'modern art', 'symbolic figure', 'aim', 'agencies', 'images', 'image', 'computer icon', 'symbolisation', 'conceptions', 'carvings', 'bods', 'aims', 'conception', 'internal representation', 'symbolic representations', 'symbolizations', 'abstract design', 'plans']
+
+**Description**: The image shows a red 3D model of a letter "F" with a hole in its center, resembling a floppy disk drive icon. It has a simple and clean design, commonly used to represent file systems or storage devices.
+
+
+
+**Asset**: cardboard_box_closed
+
+![Thumbnail](packs/cyberpunk/assets/cardboard_box_closed/thumbnail.png)   
+
+**Tags**: ['upwards', 'dispirited', 'stop', 'ripe', 'advancing', 'symbolisation', 'pointers', 'regular hexahedron', 'icon', 'symbolizations', 'transmitter', 'symbolization', 'astirs', 'occlusion', 'forward moving', 'advancings', 'down feather', 'down pat', 'left hands', 'feebleminded', 'leftovers', 'counselings', 'arrowhead', 'picture']
+
+**Description**: The image displays a 3D model of a cube with a yellow arrow pointing upwards from its center. The cube appears to be made of a translucent material and has a simple, clean design. It is set against a black background that provides contrast and highlights the object. There are no texts or additional elements in the image.
+
+
+
+**Asset**: cardboard_box_open
+
+![Thumbnail](packs/cyberpunk/assets/cardboard_box_open/thumbnail.png)   
+
+**Tags**: ['mere', 'mat', 'newspaper publisher', 'president', 'piece of furniture', 'cartonfuls', 'colourfuls', 'xanthou', 'paper', 'furniture', 'lily livereds', 'flat', 'unlifelikes', 'meres', 'chairwomen', 'composition boards', 'constructions', 'unassembled', 'composition', 'simple', 'chair', 'unlifelike', 'targets', 'mats']
+
+**Description**: The image displays a yellow cardboard box with a black outline, set against a dark background. It appears to be a simple and clean representation of a three-dimensional object, likely intended for use in a digital or virtual environment.
+
+
+
+**Asset**: chopsticks
+
+![Thumbnail](packs/cyberpunk/assets/chopsticks/thumbnail.png)   
+
+**Tags**: ['synopsi', 'bod', 'new', 'material body', 'texture', 'argumentations', 'contrast', 'abstract', 'art', 'simplenes', 'formulas', 'bodoni fonts', 'grains', 'geometricals', 'synopsis', 'material bodies', 'digital', 'dividing lines', 'simmplenes', 'argumentation', 'clean', 'edward d white', 'nonobjectives', 'vivids']
+
+**Description**: The image shows a black and white 3D rendering of a rectangular object with a wavy pattern on its surface.
+
+
+
+**Asset**: cigarettes
+
+![Thumbnail](packs/cyberpunk/assets/cigarettes/thumbnail.png)   
+
+**Tags**: ['smokes', 'tobacco plants', 'quads', 'wellness', 'monition', 'pollution', 'cigarets', 'encroachments', 'severes', 'xanthou', 'bedding material', 'smoke', 'coffin nail', 'lily livereds', 'cigarettes', 'dependencies', 'endangerment', 'venomous', 'defilements', 'poisonous', 'hazard', 'venomou', 'severe', 'quad']
+
+**Description**: The image shows a collection of three-dimensional models that appear to be cigarette butts and a lighter, set against a black background.
+
+
+
+**Asset**: coffee_house
+
+![Thumbnail](packs/cyberpunk/assets/coffee_house/thumbnail.png)   
+
+**Tags**: ['stop', 'bod', 'mental image', 'material body', 'figure of speech', 'interpretation', 'text edition', '3d rendering', 'clean lines', 'visual aspect', 'control surfaces', 'argumentations', 'constructs', 'legal actions', 'regular hexahedron', 'interlingual renditions', 'apparent motions', 'occlusion', 'activity', 'black cube', 'material bodies', 'dark block', 'abstract concept', 'solitary object']
+
+**Description**: The image shows a three-dimensional model of a black cube with a glossy surface, set against a dark background. The cube appears to have a reflective quality and there are small white dots or specks on its surface, which could represent light sources or reflections.
+
+
+
+**Asset**: coffee_machine
+
+![Thumbnail](packs/cyberpunk/assets/coffee_machine/thumbnail.png)   
+
+**Tags**: ['mere', 'synopsi', 'new', 'mat', 'abstract', 'regular hexahedron', 'flat', 'bodoni fonts', 'meres', 'geometricals', 'monochrome', 'synopsis', 'monochromatic', 'simple', 'mats', 'clean', 'edward d white', 'wide eyeds', 'nonobjectives', 'regular hexahedrons', 'vivids', 'wide eyed', 'ashens', 'bares']
+
+**Description**: The image depicts a three-dimensional model of a black cube with a shiny surface, set against a dark background. The cube appears to have a reflective quality and is presented in a way that suggests it could be used for various purposes such as 3D printing or computer graphics.
 

--- a/test-output.md
+++ b/test-output.md
@@ -1,0 +1,31 @@
+# Auto Tag Assets
+
+Tests using OLLAMA and LLAVA for asset tagging and desription generation.
+
+## Tests
+
+
+    **Asset**: data.json
+    ![Thumbnail](packs/cyberpunk/assets/a_blue/thumbnail.png)    
+    **Tags**: ['flesh', 'conventionaliseds', 'symbolic representation', 'alphabet', 'gloomy', 'missives', 'grim', 'symbolisation', 'print', 'first principle', 'pulley block', 'tag end', 'shape', 'signified', 'agency', 'body structures', 'abstract entity', 'gloomies', 'descriptors', 'stigmatization', 'substance', 'variants', 'abstraction', 'shred']
+    **Description**: The image displays a three-dimensional model of an abstract letter "A" with a simple design and a blue color scheme. It appears to be a stylized representation of the letter "A," possibly for use in graphic design or as part of a logo.
+
+    **Asset**: data.json
+    ![Thumbnail](packs/cyberpunk/assets/a_red/thumbnail.png)    
+    **Tags**: ['reports', 'holy scripture', 'flesh', 'symbolic representation', 'alphabet', 'print', 'missives', 'body structures', 'symbolisation', 'first principle', 'shape', 'logotype', 'records', 'emblematicals', 'variants', 'stigmatization', 'substance', 'document', 'components', 'upper case letter', 'import', 'designing', 'social functions', 'fount']
+    **Description**: The image shows a stylized red letter 'A' with a three-dimensional appearance, set against a black background.
+
+    **Asset**: data.json
+    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_black/thumbnail.png)    
+    **Tags**: ['time slots', 'filmdom', 'gaming console', 'colonnades', 'nostalgic gaming', 'clits', 'gambling', 'joystick', 'organisations', 'stick', 'cars', 'gamer machine', 'push buttons', 'realness', 'expansion slot', 'interpretings', 'political machines', 'realism', 'gamblings', 'cabinets', 'one armed bandit', 'nontextual matters', 'display screen', 'concealments']
+    **Description**: The image shows a 3D model of an arcade machine with a small screen and buttons on the front. It has a classic design with a dark color scheme.
+
+    **Asset**: data.json
+    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_blue/thumbnail.png)    
+    **Tags**: ['vintage', 'department of the interior', 'filmdom', 'lawsuit', 'casing', 'colonnades', 'nostalgic', 'shows', 'clits', 'threshold', 'joystick', 'restraints', 'stick', 'video game machine', 'cars', 'push buttons', 'arcade', 'consoles', 'political machines', 'subjects', 'storage lockers', 'cabinets', 'controller', 'doorway']
+    **Description**: The image shows a 3D model of an arcade machine with a blue and white color scheme, featuring a screen displaying what appears to be a game interface, buttons, joysticks, and a coin slot on the front.
+
+    **Asset**: data.json
+    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_green/thumbnail.png)    
+    **Tags**: ['flesh', 'time slots', 'lawsuit', 'casing', 'colonnades', 'shows', 'clits', 'gambling', 'joystick', 'stick', 'cars', 'push buttons', 'expansion slot', 'dash', 'political machines', 'plots', 'video game', 'subjects', 'gamblings', 'plastic case', 'one armed bandit', 'signed', 'pixel art style', 'plot']
+    **Description**: The image shows a 3D model of an arcade machine with a green top and a screen displaying what appears to be a game interface, set against a black background.

--- a/test-output.md
+++ b/test-output.md
@@ -5,27 +5,52 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 ## Tests
 
 
-    **Asset**: data.json
-    ![Thumbnail](packs/cyberpunk/assets/a_blue/thumbnail.png)    
-    **Tags**: ['flesh', 'conventionaliseds', 'symbolic representation', 'alphabet', 'gloomy', 'missives', 'grim', 'symbolisation', 'print', 'first principle', 'pulley block', 'tag end', 'shape', 'signified', 'agency', 'body structures', 'abstract entity', 'gloomies', 'descriptors', 'stigmatization', 'substance', 'variants', 'abstraction', 'shred']
-    **Description**: The image displays a three-dimensional model of an abstract letter "A" with a simple design and a blue color scheme. It appears to be a stylized representation of the letter "A," possibly for use in graphic design or as part of a logo.
 
-    **Asset**: data.json
-    ![Thumbnail](packs/cyberpunk/assets/a_red/thumbnail.png)    
-    **Tags**: ['reports', 'holy scripture', 'flesh', 'symbolic representation', 'alphabet', 'print', 'missives', 'body structures', 'symbolisation', 'first principle', 'shape', 'logotype', 'records', 'emblematicals', 'variants', 'stigmatization', 'substance', 'document', 'components', 'upper case letter', 'import', 'designing', 'social functions', 'fount']
-    **Description**: The image shows a stylized red letter 'A' with a three-dimensional appearance, set against a black background.
+**Asset**: a_blue
 
-    **Asset**: data.json
-    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_black/thumbnail.png)    
-    **Tags**: ['time slots', 'filmdom', 'gaming console', 'colonnades', 'nostalgic gaming', 'clits', 'gambling', 'joystick', 'organisations', 'stick', 'cars', 'gamer machine', 'push buttons', 'realness', 'expansion slot', 'interpretings', 'political machines', 'realism', 'gamblings', 'cabinets', 'one armed bandit', 'nontextual matters', 'display screen', 'concealments']
-    **Description**: The image shows a 3D model of an arcade machine with a small screen and buttons on the front. It has a classic design with a dark color scheme.
+![Thumbnail](packs/cyberpunk/assets/a_blue/thumbnail.png)   
 
-    **Asset**: data.json
-    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_blue/thumbnail.png)    
-    **Tags**: ['vintage', 'department of the interior', 'filmdom', 'lawsuit', 'casing', 'colonnades', 'nostalgic', 'shows', 'clits', 'threshold', 'joystick', 'restraints', 'stick', 'video game machine', 'cars', 'push buttons', 'arcade', 'consoles', 'political machines', 'subjects', 'storage lockers', 'cabinets', 'controller', 'doorway']
-    **Description**: The image shows a 3D model of an arcade machine with a blue and white color scheme, featuring a screen displaying what appears to be a game interface, buttons, joysticks, and a coin slot on the front.
+**Tags**: ['varsity letter', 'intentionals', 'intentional', 'alphabetic characters', 'letter', 'alphabetic character', 'letter of the alphabet', 'varsity letters', 'cleverly designed']
 
-    **Asset**: data.json
-    ![Thumbnail](packs/cyberpunk/assets/arcade_machine_green/thumbnail.png)    
-    **Tags**: ['flesh', 'time slots', 'lawsuit', 'casing', 'colonnades', 'shows', 'clits', 'gambling', 'joystick', 'stick', 'cars', 'push buttons', 'expansion slot', 'dash', 'political machines', 'plots', 'video game', 'subjects', 'gamblings', 'plastic case', 'one armed bandit', 'signed', 'pixel art style', 'plot']
-    **Description**: The image shows a 3D model of an arcade machine with a green top and a screen displaying what appears to be a game interface, set against a black background.
+**Description**: The image shows a stylized, three-dimensional letter "A" with a modern and clean design, rendered in a blue color on a black background.
+
+
+
+**Asset**: a_red
+
+![Thumbnail](packs/cyberpunk/assets/a_red/thumbnail.png)   
+
+**Tags**: ['textual matters', 'conceptions', 'a', 'antiophthalmic factor', 'alphabetic characters', 'reddened', 'letter', 'alphabetic character', 'symbolisation', 'blood red', 'symbolization', 'baptistries', 'purposes', 'reddish', 'baptismal font', 'symbol', 'textbook', 'varsity letter', 'school text', 'baptistry', 'red', 'reddishes', 'symbolisations', 'monogram']
+
+**Description**: The image displays a three-dimensional rendering of an abstract letter 'A' with a red outline and a black fill, set against a dark background.
+
+
+
+**Asset**: arcade_machine_black
+
+![Thumbnail](packs/cyberpunk/assets/arcade_machine_black/thumbnail.png)   
+
+**Tags**: ['conceptions', 'restraint', 'motorcar', 'ascendencies', 'arcade machine', 'unit of measurement', 'gambling', 'showing', 'nontextual matters', 'gimmick', 'modelling', 'ascendancies', 'automobile', 'car', 'vibration', 'gamblings', 'collectors item', 'vibrations', 'electronic device', 'conception', 'pixel art', 'prowess', 'gimmicks', 'twist']
+
+**Description**: The image shows a 3D model of an arcade machine with a screen displaying a game interface and buttons for controls.
+
+
+
+**Asset**: arcade_machine_blue
+
+![Thumbnail](packs/cyberpunk/assets/arcade_machine_blue/thumbnail.png)   
+
+**Tags**: ['comptroller', 'gaming unit', 'time slots', 'motorcar', 'display screen', 'covert', 'one armed bandit', 'video game console', 'cabinets', 'loudspeakers', 'loudspeaker', 'arcade machine', 'unit of measurement', 'index numbers', 'button panel', 'cabinet', 'indicant', 'comptrollers', 'expansion slot', 'power indicator', 'whole', 'details', 'talker', 'console table']
+
+**Description**: The image displays a 3D model of an arcade machine with a blue exterior and a clear glass front, featuring a control panel with buttons and joysticks, and a screen displaying what appears to be a game interface with red and green elements.
+
+
+
+**Asset**: arcade_machine_green
+
+![Thumbnail](packs/cyberpunk/assets/arcade_machine_green/thumbnail.png)   
+
+**Tags**: ['playthings', 'public figure', 'motorcar', 'theoretical accounts', 'anatomy', 'fig', 'gamy', 'anatomies', 'spunkies', 'arcade game', 'collectable', 'leisure time', 'amusement', 'video displays', 'showing', 'action figure', 'details', 'leisure', 'gimmick', 'modelling', 'automobile', 'model', 'gameys', 'illumination']
+
+**Description**: The image shows a 3D model of an arcade machine with a green top and a blue screen displaying what appears to be a game interface. The machine has two joysticks on the front panel and several buttons around them. It is placed against a black background, emphasizing its design and features.
+

--- a/tools/auto_tag_assets_ollama.py
+++ b/tools/auto_tag_assets_ollama.py
@@ -6,6 +6,7 @@ from tqdm import tqdm
 import spacy
 import nltk
 import inflect
+from readne_generator import ReadmeGenerator
 
 try:
     from nltk.corpus import wordnet as wn
@@ -138,6 +139,8 @@ def save_json(p: Path, obj: dict):
         fh.write("\n")
 
 def main():
+    readme_generator = ReadmeGenerator()
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--assets-root", required=True)
     ap.add_argument("--max-tags", type=int, default=24)
@@ -219,9 +222,17 @@ def main():
 
         if args.dry_run:
             print(f"[DRY] {data_json.name}: +{final_tags}  description='" + caption + "'")
+            readme_generator.add_asset(
+                data_json.name, 
+                thumb,
+                final_tags, 
+                caption,
+            )
         else:
             save_json(data_json, obj)
         processed += 1
+    
+    readme_generator.renderize_readme()
 
 if __name__ == "__main__":
     main()

--- a/tools/readne_generator.py
+++ b/tools/readne_generator.py
@@ -19,7 +19,7 @@ class ReadmeGenerator:
     
     def renderize_readme(self):
 
-        env = Environment(loader=FileSystemLoader("templataes"))
+        env = Environment(loader=FileSystemLoader("templates"))
         template = env.get_template("README.template.md")
 
         output = template.render(self.assets)

--- a/tools/readne_generator.py
+++ b/tools/readne_generator.py
@@ -12,7 +12,7 @@ class ReadmeGenerator:
     
     def add_asset(self, asset, thumbnail, tags, description):
         asset_objet = {
-            "asset": asset,
+            "asset": str(thumbnail).split('assets/')[1].split("/thumbnail")[0],
             "thumbnail": str(thumbnail).split('asset-packs/')[1],
             "tags": tags,
             "description": description,

--- a/tools/readne_generator.py
+++ b/tools/readne_generator.py
@@ -1,0 +1,34 @@
+from jinja2 import Environment, FileSystemLoader
+
+class ReadmeGenerator:
+    """
+    Gathers the assets processed with the tags and description generated.
+    Renders README with assets inf for viz.
+    """
+    def __init__(self):
+        self.assets = []
+    
+    def add_asset(self, asset, thumbnail, tags, description):
+        asset_objet = {
+            "asset": asset,
+            "thumbnail": thumbnail,
+            "tags": tags,
+            "description": description,
+        }
+        self.assets.append(asset_objet)
+    
+    def renderize_readme(self):
+
+        env = Environment(loader=FileSystemLoader("templataes"))
+        template = env.get_template("README.template.md")
+
+        output = template.render(self.assets)
+
+        with open("test-output.md", "w", encoding="utf-8") as f:
+            f.write(output)
+
+        print("Test report renderized successfully.")
+
+        pass
+
+

--- a/tools/readne_generator.py
+++ b/tools/readne_generator.py
@@ -1,4 +1,6 @@
+import os
 from jinja2 import Environment, FileSystemLoader
+
 
 class ReadmeGenerator:
     """
@@ -11,7 +13,7 @@ class ReadmeGenerator:
     def add_asset(self, asset, thumbnail, tags, description):
         asset_objet = {
             "asset": asset,
-            "thumbnail": thumbnail,
+            "thumbnail": str(thumbnail).split('asset-packs/')[1],
             "tags": tags,
             "description": description,
         }
@@ -19,10 +21,14 @@ class ReadmeGenerator:
     
     def renderize_readme(self):
 
-        env = Environment(loader=FileSystemLoader("templates"))
+        BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+        TEMPLATE_DIR = os.path.join(BASE_DIR, "templates")
+
+        env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
         template = env.get_template("README.template.md")
 
-        output = template.render(self.assets)
+        output = template.render(assets=self.assets)
 
         with open("test-output.md", "w", encoding="utf-8") as f:
             f.write(output)

--- a/tools/templates/README.template.md
+++ b/tools/templates/README.template.md
@@ -5,8 +5,13 @@ Tests using OLLAMA and LLAVA for asset tagging and desription generation.
 ## Tests
 
 {% for asset in assets %}
-    **Asset**: {{ asset.asset }}
-    ![Thumbnail]({{ asset.thumbnail }})    
-    **Tags**: {{ asset.tags }}
-    **Description**: {{ asset.description }}
+
+**Asset**: {{ asset.asset }}
+
+![Thumbnail]({{ asset.thumbnail }})   
+
+**Tags**: {{ asset.tags }}
+
+**Description**: {{ asset.description }}
+
 {% endfor %}

--- a/tools/templates/README.template.md
+++ b/tools/templates/README.template.md
@@ -1,0 +1,12 @@
+# Auto Tag Assets
+
+Tests using OLLAMA and LLAVA for asset tagging and desription generation.
+
+## Tests
+
+{% for asset in assets %}
+    **Asset**: {{ asset.asset }}
+    ![Thumbnail]({{ asset.thumbnail }})    
+    **Tags**: {{ asset.tags }}
+    **Description**: {{ asset.description }}
+{% endfor %}


### PR DESCRIPTION

# Problem

We don't have an easy way of visualizing the results of a test run to evaluate performane.

# Solution

Add ReadmeGenerator class, that gathers asset info when processed and builds a report ooutputed to output-test.md for evaluation.
