### PR TITLE
fix: Revert tween to basic view v1

### DIFF
--- a/packs/smart_items/assets/vertical_platform_genesis/composite.json
+++ b/packs/smart_items/assets/vertical_platform_genesis/composite.json
@@ -157,90 +157,21 @@
         "0": {
           "json": {
             "isBasicViewEnabled": true,
-            "label": "Vertical Platform",
-            "version": 2,
-            "sections": [
+            "componentName": "Vertical Platform",
+            "fields": [
               {
-                "id": "tween-settings",
-                "items": [
-                  {
-                    "component": "core::Tween",
-                    "widget": "RangeField",
-                    "label": "Height",
-                    "path": "mode.move.end.y",
-                    "constraints": {
-                      "step": 0.1
-                    },
-                    "transform": {
-                      "in": {
-                        "steps": [{ "op": "toNumber" }, { "op": "toFixed" }]
-                      },
-                      "out": {
-                        "steps": [{ "op": "toNumber" }]
-                      }
-                    }
-                  },
-                  {
-                    "component": "core::Tween",
-                    "widget": "RangeField",
-                    "label": "Duration",
-                    "path": "duration",
-                    "constraints": {
-                      "step": 1
-                    },
-                    "transform": {
-                      "in": {
-                        "steps": [
-                          {
-                            "op": "millisecondsToSeconds"
-                          }
-                        ]
-                      },
-                      "out": {
-                        "steps": [
-                          {
-                            "op": "secondsToMilliseconds"
-                          }
-                        ]
-                      }
-                    }
-                  }
-                ]
+                "name": "Tween",
+                "type": "core::Tween"
               },
               {
-                "id": "tween-settings-auto-start-loop",
-                "items": [
-                  {
-                    "component": "core::Tween",
-                    "widget": "CheckboxField",
-                    "label": "Auto Start",
-                    "path": "playing"
-                  },
-                  {
-                    "component": "core::TweenSequence",
-                    "widget": "CheckboxField",
-                    "label": "Loop",
-                    "path": "loop"
-                  }
-                ],
-                "columns": 2
+                "name": "When End Reached",
+                "type": "asset-packs::Triggers",
+                "basicViewId": "trigger-when-end-reached"
               },
               {
-                "id": "triggers-settings",
-                "items": [
-                  {
-                    "component": "asset-packs::Triggers",
-                    "widget": "TriggerSection",
-                    "label": "When End Reached",
-                    "basicViewId": "trigger-when-end-reached"
-                  },
-                  {
-                    "component": "asset-packs::Triggers",
-                    "widget": "TriggerSection",
-                    "label": "When Start Reached",
-                    "basicViewId": "trigger-when-start-reached"
-                  }
-                ]
+                "name": "When Start Reached",
+                "type": "asset-packs::Triggers",
+                "basicViewId": "trigger-when-start-reached"
               }
             ]
           }


### PR DESCRIPTION
This PR reverts the vertical platform basic view to the legacy one